### PR TITLE
added better error reporting capability for Result<,> type

### DIFF
--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.csproj
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.csproj
@@ -12,19 +12,23 @@
     <PackageTags>functional, MSTest, MSTest2, NUnit, xUnit2, xUnit, TDD, Fluent, netcore, netstandard</PackageTags>
     <PackageLicenseUrl>https://github.com/RyanMarcotte/Functional.Utilities/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.Utilities</PackageProjectUrl>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>D:\Projects\Functional.Utilities\src\Functional.Primitives.FluentAssertions\Functional.Primitives.FluentAssertions\Functional.Primitives.FluentAssertions.xml</DocumentationFile>
+    <DocumentationFile>Functional.Primitives.FluentAssertions.xml</DocumentationFile>
+    <OutputPath>bin\Debug</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>D:\Projects\Functional.Utilities\src\Functional.Primitives.FluentAssertions\Functional.Primitives.FluentAssertions\Functional.Primitives.FluentAssertions.xml</DocumentationFile>
+    <DocumentationFile>Functional.Primitives.FluentAssertions.xml</DocumentationFile>
+    <OutputPath>bin\Release</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
     <PackageReference Include="Functional.Primitives" Version="1.9.0" />
+    <PackageReference Include="Functional.Primitives.Extensions" Version="1.9.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.xml
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.xml
@@ -97,10 +97,27 @@
             <param name="because">Additional information for if the assertion fails.</param>
             <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because"/>.</param>
         </member>
+        <member name="M:Functional.Primitives.FluentAssertions.ResultTypeAssertions`2.BeSuccessful(System.Func{`1,System.String},System.String,System.Object[])">
+            <summary>
+            Verifies that the subject <see cref="T:Functional.Result`2"/> holds a successful result.
+            </summary>
+            <param name="faultedResultDescriptionFactory">The function used to construct a message describing the faulted result.</param>
+            <param name="because">Additional information for if the assertion fails.</param>
+            <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because"/>.</param>
+        </member>
         <member name="M:Functional.Primitives.FluentAssertions.ResultTypeAssertions`2.BeSuccessful(System.Action{`0},System.String,System.Object[])">
             <summary>
             Verifies that the subject <see cref="T:Functional.Result`2"/> holds a successful result.  If so, execute an action that can be used to perform additional assertions.
             </summary>
+            <param name="additionalAssertionAction">The action used to perform additional assertions.</param>
+            <param name="because">Additional information for if the assertion fails.</param>
+            <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because"/>.</param>
+        </member>
+        <member name="M:Functional.Primitives.FluentAssertions.ResultTypeAssertions`2.BeSuccessful(System.Func{`1,System.String},System.Action{`0},System.String,System.Object[])">
+            <summary>
+            Verifies that the subject <see cref="T:Functional.Result`2"/> holds a successful result.  If so, execute an action that can be used to perform additional assertions.
+            </summary>
+            <param name="faultedResultDescriptionFactory">The function used to construct a message describing the faulted result.</param>
             <param name="additionalAssertionAction">The action used to perform additional assertions.</param>
             <param name="because">Additional information for if the assertion fails.</param>
             <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because"/>.</param>
@@ -129,10 +146,27 @@
             <param name="because">Additional information for if the assertion fails.</param>
             <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because"/>.</param>
         </member>
+        <member name="M:Functional.Primitives.FluentAssertions.ResultTypeAssertions`2.BeFaulted(System.Func{`0,System.String},System.String,System.Object[])">
+            <summary>
+            Verifies that the subject <see cref="T:Functional.Result`2"/> holds a faulted result.
+            </summary>
+            <param name="successfulResultDescriptionFactory">The function used to construct a message describing the successful result.</param>
+            <param name="because">Additional information for if the assertion fails.</param>
+            <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because"/>.</param>
+        </member>
         <member name="M:Functional.Primitives.FluentAssertions.ResultTypeAssertions`2.BeFaulted(System.Action{`1},System.String,System.Object[])">
             <summary>
             Verifies that the subject <see cref="T:Functional.Result`2"/> holds a faulted result.  If so, execute an action that can be used to perform additional assertions.
             </summary>
+            <param name="additionalAssertionAction">The action used to perform additional assertions.</param>
+            <param name="because">Additional information for if the assertion fails.</param>
+            <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because"/>.</param>
+        </member>
+        <member name="M:Functional.Primitives.FluentAssertions.ResultTypeAssertions`2.BeFaulted(System.Func{`0,System.String},System.Action{`1},System.String,System.Object[])">
+            <summary>
+            Verifies that the subject <see cref="T:Functional.Result`2"/> holds a faulted result.  If so, execute an action that can be used to perform additional assertions.
+            </summary>
+            <param name="successfulResultDescriptionFactory">The function used to construct a message describing the successful result.</param>
             <param name="additionalAssertionAction">The action used to perform additional assertions.</param>
             <param name="because">Additional information for if the assertion fails.</param>
             <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because"/>.</param>

--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/OptionTypeAssertions.cs
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/OptionTypeAssertions.cs
@@ -32,8 +32,6 @@ namespace Functional.Primitives.FluentAssertions
 		/// <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because"/>.</param>
 		public void HaveValue(string because = "", params object[] becauseArgs)
 		{
-			((object)_subject).Should().NotBeNull();
-
 			Execute.Assertion
 				.ForCondition(_subject.HasValue())
 				.BecauseOf(because, becauseArgs)
@@ -89,8 +87,6 @@ namespace Functional.Primitives.FluentAssertions
 		/// <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because"/>.</param>
 		public void NotHaveValue(string because = "", params object[] becauseArgs)
 		{
-			((object)_subject).Should().NotBeNull();
-
 			Execute.Assertion
 				.ForCondition(!_subject.HasValue())
 				.BecauseOf(because, becauseArgs)


### PR DESCRIPTION
The more I used this library, the more I wanted the ability to know what faulted object was coming back when I expected success (or what successful object was coming back when I expected failure).  These changes add that functionality without colliding with the existing assertion methods.

The most common scenario is some `Result<T, Exception>` being faulted when I expect successful `T`, and I want the ability to see what the `Exception` is without having to debug the test.