### PR TITLE
Add equality assertions

### DIFF
--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.Tests/OptionTypeAssertionsTests.cs
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.Tests/OptionTypeAssertionsTests.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using FluentAssertions;
 using Xunit;
 
@@ -50,6 +48,173 @@ namespace Functional.Primitives.FluentAssertions.Tests
 
 			[Fact]
 			public void ShouldThrowException() => new Action(() => Option.Some(3).Should().NotHaveValue()).Should().Throw<Exception>();
+		}
+
+		public class IntegerOptionChecks
+		{
+			private const int VALUE = 54;
+
+			[Fact]
+			public void ShouldNotThrowExceptionWhenBothSomeAndSameValues() => new Action(() =>
+			{
+				Option.Some(VALUE)
+					.Should()
+					.Be(Option.Some(VALUE));
+			}).Should().NotThrow();
+
+			[Fact]
+			public void ShouldNotThrowExceptionWhenBothNone() => new Action(() =>
+			{
+				Option.None<int>()
+					.Should()
+					.Be(Option.None<int>());
+			}).Should().NotThrow();
+
+			[Fact]
+			public void ShouldThrowExceptionWhenBothSomeButDifferentValues() => new Action(() =>
+			{
+				Option.Some(VALUE)
+					.Should()
+					.Be(Option.Some(VALUE+1));
+			}).Should().Throw<Exception>();
+
+			[Fact]
+			public void ShouldThrowExceptionWhenLeftIsSomeButRightIsNone() => new Action(() =>
+			{
+				Option.Some(VALUE)
+					.Should()
+					.Be(Option.None<int>());
+			}).Should().Throw<Exception>();
+
+			[Fact]
+			public void ShouldThrowExceptionWhenLeftIsNoneButRightIsSome() => new Action(() =>
+			{
+				Option.None<int>()
+					.Should()
+					.Be(Option.Some(VALUE));
+			}).Should().Throw<Exception>();
+		}
+
+		public class StringOptionChecks
+		{
+			private const string VALUE = "test";
+
+			[Fact]
+			public void ShouldNotThrowExceptionWhenBothSomeAndSameValues() => new Action(() =>
+			{
+				Option.Some(VALUE)
+					.Should()
+					.Be(Option.Some(VALUE));
+			}).Should().NotThrow();
+
+			[Fact]
+			public void ShouldNotThrowExceptionWhenBothNone() => new Action(() =>
+			{
+				Option.None<string>()
+					.Should()
+					.Be(Option.None<string>());
+			}).Should().NotThrow();
+
+			[Fact]
+			public void ShouldThrowExceptionWhenBothSomeButDifferentValues() => new Action(() =>
+			{
+				Option.Some(VALUE)
+					.Should()
+					.Be(Option.Some(VALUE + 1));
+			}).Should().Throw<Exception>();
+
+			[Fact]
+			public void ShouldThrowExceptionWhenLeftIsSomeButRightIsNone() => new Action(() =>
+			{
+				Option.Some(VALUE)
+					.Should()
+					.Be(Option.None<string>());
+			}).Should().Throw<Exception>();
+
+			[Fact]
+			public void ShouldThrowExceptionWhenLeftIsNoneButRightIsSome() => new Action(() =>
+			{
+				Option.None<string>()
+					.Should()
+					.Be(Option.Some(VALUE));
+			}).Should().Throw<Exception>();
+		}
+
+		public class EquatableClassOptionChecks
+		{
+			private const int VALUE = 1337;
+
+			[Fact]
+			public void ShouldNotThrowExceptionWhenBothSomeAndSameValues() => new Action(() =>
+			{
+				Option.Some(new EquatableClass(VALUE))
+					.Should()
+					.Be(Option.Some(new EquatableClass(VALUE)));
+			}).Should().NotThrow();
+
+			[Fact]
+			public void ShouldNotThrowExceptionWhenBothNone() => new Action(() =>
+			{
+				Option.None<string>()
+					.Should()
+					.Be(Option.None<string>());
+			}).Should().NotThrow();
+
+			[Fact]
+			public void ShouldThrowExceptionWhenBothSomeButDifferentValues() => new Action(() =>
+			{
+				Option.Some(new EquatableClass(VALUE))
+					.Should()
+					.Be(Option.Some(new EquatableClass(VALUE + 1)));
+			}).Should().Throw<Exception>();
+
+			[Fact]
+			public void ShouldThrowExceptionWhenLeftIsSomeButRightIsNone() => new Action(() =>
+			{
+				Option.Some(new EquatableClass(VALUE))
+					.Should()
+					.Be(Option.None<EquatableClass>());
+			}).Should().Throw<Exception>();
+
+			[Fact]
+			public void ShouldThrowExceptionWhenLeftIsNoneButRightIsSome() => new Action(() =>
+			{
+				Option.None<EquatableClass>()
+					.Should()
+					.Be(Option.Some(new EquatableClass(VALUE)));
+			}).Should().Throw<Exception>();
+
+			#region Models
+
+			private class EquatableClass : IEquatable<EquatableClass>
+			{
+				public EquatableClass(int value)
+				{
+					Value = value;
+				}
+
+				public int Value { get; }
+
+				public bool Equals(EquatableClass other)
+				{
+					if (other is null) return false;
+					if (ReferenceEquals(this, other)) return true;
+					return Value == other.Value;
+				}
+
+				public override bool Equals(object obj)
+				{
+					if (obj is null) return false;
+					if (ReferenceEquals(this, obj)) return true;
+					return obj.GetType() == GetType() && Equals((EquatableClass)obj);
+				}
+
+				public override int GetHashCode() => Value;
+				public static bool operator ==(EquatableClass left, EquatableClass right) => Equals(left, right);
+				public static bool operator !=(EquatableClass left, EquatableClass right) => !Equals(left, right);
+			}
+
+			#endregion
 		}
 	}
 }

--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.Tests/ResultTypeAssertionsTests.cs
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.Tests/ResultTypeAssertionsTests.cs
@@ -69,5 +69,60 @@ namespace Functional.Primitives.FluentAssertions.Tests
 
 			}).Should().Throw<Exception>();
 		}
+
+		public class EqualityChecks
+		{
+			[Fact]
+			public void ShouldNotThrowExceptionWhenBothSuccessAndBothHaveSameSuccessValues() => new Action(() =>
+			{
+				Result.Success<int, string>(1337)
+					.Should()
+					.Be(Result.Success<int, string>(1337));
+			}).Should().NotThrow();
+
+			[Fact]
+			public void ShouldNotThrowExceptionWhenBothFaultedAndBothHaveSameFailureValues() => new Action(() =>
+			{
+				Result.Failure<int, string>("error")
+					.Should()
+					.Be(Result.Failure<int, string>("error"));
+			}).Should().NotThrow();
+
+			[Fact]
+			public void ShouldThrowExceptionWhenBothSuccessButHaveDifferentSuccessValues() => new Action(() =>
+			{
+				Result.Success<int, string>(3)
+					.Should()
+					.Be(Result.Success<int, string>(4));
+
+			}).Should().Throw<Exception>();
+
+			[Fact]
+			public void ShouldThrowExceptionWhenBothFaultedButHaveDifferentFailureValues() => new Action(() =>
+			{
+				Result.Failure<int, string>("1")
+					.Should()
+					.Be(Result.Failure<int, string>("2"));
+
+			}).Should().Throw<Exception>();
+
+			[Fact]
+			public void ShouldThrowExceptionWhenLeftIsSuccessAndRightIsFaulted() => new Action(() =>
+			{
+				Result.Success<int, string>(3)
+					.Should()
+					.Be(Result.Failure<int, string>("e"));
+
+			}).Should().Throw<Exception>();
+
+			[Fact]
+			public void ShouldThrowExceptionWhenLeftIsFaultedAndRightIsSuccess() => new Action(() =>
+			{
+				Result.Failure<int, string>("e")
+					.Should()
+					.Be(Result.Success<int, string>(3));
+
+			}).Should().Throw<Exception>();
+		}
 	}
 }

--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.csproj
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.csproj
@@ -11,7 +11,7 @@
     <RepositoryType></RepositoryType>
     <PackageTags>functional, MSTest, MSTest2, NUnit, xUnit2, xUnit, TDD, Fluent, netcore, netstandard</PackageTags>
     <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.Utilities</PackageProjectUrl>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <PackageReleaseNotes>Simplify the API by leveraging existing FluentAssertions syntax off AndValue, AndSuccessValue, AndFailureValue subject accessors:
 - option.Should().HaveValue().AndValue.Should().Be(...)
 - result.Should().BeSuccessful().AndSuccessValue.Should().Be(...)

--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.csproj
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.csproj
@@ -12,10 +12,7 @@
     <PackageTags>functional, MSTest, MSTest2, NUnit, xUnit2, xUnit, TDD, Fluent, netcore, netstandard</PackageTags>
     <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.Utilities</PackageProjectUrl>
     <Version>2.1.0</Version>
-    <PackageReleaseNotes>Simplify the API by leveraging existing FluentAssertions syntax off AndValue, AndSuccessValue, AndFailureValue subject accessors:
-- option.Should().HaveValue().AndValue.Should().Be(...)
-- result.Should().BeSuccessful().AndSuccessValue.Should().Be(...)
-- result.Should().BeFaulted().AndFailureValue.Should().Be(...)</PackageReleaseNotes>
+    <PackageReleaseNotes>Add equality check assertions (.Should().Be(...)) for Option&lt;T&gt; and Result&lt;TSuccess, TFailure&gt;</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 

--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/OptionTypeAssertions.cs
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/OptionTypeAssertions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Text;
 using FluentAssertions.Execution;
 using Functional.Primitives.FluentAssertions.Extensions;
 
@@ -21,6 +22,33 @@ namespace Functional.Primitives.FluentAssertions
 		public OptionTypeAssertions(Option<T> subject)
 		{
 			_subject = subject;
+		}
+
+		/// <summary>
+		/// Verifies that the subject is equal to an expected value.
+		/// </summary>
+		/// <param name="expected">The expected value.</param>
+		/// <param name="because">Additional information for if the assertion fails.</param>
+		/// <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because"/>.</param>
+		/// <returns></returns>
+		public OptionTypeAssertions<T> Be(Option<T> expected, string because = "", params object[] becauseArgs)
+		{
+			Execute.Assertion
+				.ForCondition(_subject.Equals(expected))
+				.BecauseOf(because, becauseArgs)
+				.FailWith(MakeFailReason);
+
+			return this;
+
+			FailReason MakeFailReason()
+			{
+				var builder = new StringBuilder();
+				builder.AppendLine($"Expected to be equal{{reason}}, but the two Option<{typeof(T)}> are not equal.");
+				builder.AppendLine("Subject: " + _subject);
+				builder.AppendLine("Expected: " + expected);
+
+				return new FailReason(builder.ToString());
+			}
 		}
 
 		/// <summary>
@@ -49,13 +77,15 @@ namespace Functional.Primitives.FluentAssertions
 				.ForCondition(!_subject.HasValue())
 				.BecauseOf(because, becauseArgs)
 				.FailWith(FailReasonForNotHaveValue);
-		}
 
-		private FailReason FailReasonForNotHaveValue()
-		{
-			return new FailReason("Expected to not have value{reason}, but received a value instead:"
-								  + Environment.NewLine
-			                      + _subject.ValueUnsafe());
+			FailReason FailReasonForNotHaveValue()
+			{
+				var builder = new StringBuilder();
+				builder.AppendLine("Expected to not have value{reason}, but received a value instead:");
+				builder.AppendLine(_subject.ValueUnsafe().ToString());
+
+				return new FailReason(builder.ToString());
+			}
 		}
 	}
 }

--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/OptionTypeAssertions.cs
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/OptionTypeAssertions.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Text;
+using FluentAssertions;
 using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
 using Functional.Primitives.FluentAssertions.Extensions;
 
 namespace Functional.Primitives.FluentAssertions
@@ -31,14 +33,14 @@ namespace Functional.Primitives.FluentAssertions
 		/// <param name="because">Additional information for if the assertion fails.</param>
 		/// <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because"/>.</param>
 		/// <returns></returns>
-		public OptionTypeAssertions<T> Be(Option<T> expected, string because = "", params object[] becauseArgs)
+		public AndConstraint<ObjectAssertions> Be(Option<T> expected, string because = "", params object[] becauseArgs)
 		{
 			Execute.Assertion
 				.ForCondition(_subject.Equals(expected))
 				.BecauseOf(because, becauseArgs)
 				.FailWith(MakeFailReason);
 
-			return this;
+			return new AndConstraint<ObjectAssertions>(new ObjectAssertions(_subject));
 
 			FailReason MakeFailReason()
 			{


### PR DESCRIPTION
Prior to this change, equality checks for `Option<T>` would need to use an awkward syntax in order to access the base `FluentAssertions` equality check:

```
// VariationName, VariationSku and VariationPrice all Option<T>
AssertionExtensions.Should(sut.VariationName).Be(original.VariationName);
sut.VariationSku.Should().HaveValue().AndValue.Should().Be(NEW_SKU);
AssertionExtensions.Should(sut.VariationPrice).Be(original.VariationPrice);
```

This PR enables the following syntax for performing equality checks:

```
sut.VariationName.Should().Be(original.VariationName);
sut.VariationSku.Should().HaveValue().AndValue.Should().Be(NEW_SKU);
sut.VariationPrice.Should().Be(original.VariationPrice);
```

I have made the applicable changes to enable fluent equality checks for `Result<TSuccess, TFailure>` too.