### PR TITLE
Adds extension methods for Task wrapped Result and Option type assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,41 @@ var otherOption = Option.Some(1337);
 option.Should().Be(otherOption);
 ```
 
+## `Task<Option<T>>`
+
+### `HaveValue`
+
+``` csharp
+var optionTask = Task.FromResult(Option.Some(1337));
+
+// await the task and verify that the resulting option contains a value
+await optionTask.Should().HaveValue();
+
+// await the task and verify that the resulting option contains a value and that the contained value matches some condition(s)
+await optionTask.Should().HaveValue().AndValue(v => v.Should().Be(1337));
+await optionTask.Should().HaveValue().AndValue(v => v.Should().BeGreaterThanOrEqualTo(0));
+await optionTask.Should().HaveValue().AndValue(v => v.Should().BeGreaterThanOrEqualTo(0).And.LessThanOrEqualTo(2000));
+```
+
+### `NotHaveValue`
+
+``` csharp
+var optionTask = Task.FromResult(Option.None<int>());
+
+// await the task and verify that the resulting option does not have a value
+await optionTask.Should().NotHaveValue();
+```
+
+### `Be`
+
+``` csharp
+var optionTask = Task.FromResult(Option.Some(1337));
+var otherOption = Task.FromResult(Option.Some(1337));
+
+// await the task and verify that the resulting option is equal to another option
+await optionTask.Should().Be(otherOption);
+```
+
 ## `Result<TSuccess, TFailure>`
 
 ### `BeSuccessful`
@@ -74,4 +109,43 @@ var otherResult = Result.Success<int, string>(1337);
 
 // verify that the result is equal to another result
 result.Should().Be(otherResult);
+```
+
+## `Task<Result<TSuccess, TFailure>>`
+
+### `BeSuccessful`
+
+``` csharp
+var resultTask = Task.FromResult(Result.Success<int, string>(1337));
+
+// await the Task and verify that the result represents a successful value
+await resultTask.Should().BeSuccessful();
+
+// await the Task and verify that the result represents a successful value and that the contained value matches some condition(s)
+await resultTask.Should().BeSuccessful().AndSuccessValue(s => s.Should().Be(1337));
+await resultTask.Should().BeSuccessful().AndSuccessValue(s => s.Should().BeGreaterThanOrEqualTo(0));
+await resultTask.Should().BeSuccessful().AndSuccessValue(s => s.Should().BeGreaterThanOrEqualTo(0).And.BeLessThanOrEqualTo(2000));
+```
+
+### `BeFaulted`
+
+``` csharp
+var resultTask = Task.FromResult(Result.Failure<int, string>(string.Empty));
+
+// await the Task and verify that the result represents a faulted value
+await resultTask.Should().BeFaulted();
+
+// await the Task and verify that the result represents a faulted value and that the contained value matches some condition(s)
+await resultTask.Should().BeFaulted().AndFailureValue(f => f.Should().Be(string.Empty));
+await resultTask.Should().BeFaulted().AndFailureValue(f => f.Should().BeNullOrWhiteSpace());
+```
+
+### `Be`
+
+``` csharp
+var resultTask = Task.FromResult(Result.Success<int, string>(1337));
+var otherResult = Result.Success<int, string>(1337);
+
+// await the Task and verify that the result is equal to another result
+await resultTask.Should().Be(otherResult);
 ```

--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.Tests/OptionTypeAssertionsExtensionsTests.cs
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.Tests/OptionTypeAssertionsExtensionsTests.cs
@@ -1,0 +1,206 @@
+﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace Functional.Primitives.FluentAssertions.Tests
+{
+	public class OptionTypeAssertionsExtensionsTests
+	{
+		public class ValueChecks
+		{
+			private const int VALUE = 3;
+
+			[Fact]
+			public void ShouldNotThrowException() => new Func<Task>(() =>
+				Task.FromResult(Option.Some(VALUE))
+					.Should()
+					.HaveValue())
+			.Should().NotThrow();
+
+			[Fact]
+			public void ShouldNotThrowExceptionWhenAdditionalAssertionSucceeds() => new Func<Task>(() =>
+				Task.FromResult(Option.Some(VALUE))
+					.Should()
+					.HaveValue()
+					.AndValue(value => value.Should().Be(VALUE)))
+			.Should().NotThrow();
+
+			[Fact]
+			public void ShouldThrowException() => new Func<Task>(() =>
+				Task.FromResult(Option.None<int>())
+					.Should()
+					.HaveValue())
+			.Should().Throw<Exception>();
+
+			[Fact]
+			public void ShouldThrowExceptionWhenAdditionalAssertionFails() => new Func<Task>(() =>
+				Task.FromResult(Option.Some(VALUE))
+					.Should()
+					.HaveValue()
+					.AndValue(value => value.Should().Be(VALUE)))
+			.Should().NotThrow();
+		}
+
+		public class NoValueChecks
+		{
+			[Fact]
+			public void ShouldNotThrowException() => new Func<Task>(() => Task.FromResult(Option.None<int>()).Should().NotHaveValue()).Should().NotThrow();
+
+			[Fact]
+			public void ShouldThrowException() => new Func<Task>(() => Task.FromResult(Option.Some(3)).Should().NotHaveValue()).Should().Throw<Exception>();
+		}
+
+		public class IntegerOptionChecks
+		{
+			private const int VALUE = 54;
+
+			[Fact]
+			public void ShouldNotThrowExceptionWhenBothSomeAndSameValues() => new Func<Task>(() =>
+				Task.FromResult(Option.Some(VALUE))
+					.Should()
+					.Be(Option.Some(VALUE)))
+			.Should().NotThrow();
+
+			[Fact]
+			public void ShouldNotThrowExceptionWhenBothNone() => new Func<Task>(() =>
+				Task.FromResult(Option.None<int>())
+					.Should()
+					.Be(Option.None<int>()))
+			.Should().NotThrow();
+
+			[Fact]
+			public void ShouldThrowExceptionWhenBothSomeButDifferentValues() => new Func<Task>(() =>
+				Task.FromResult(Option.Some(VALUE))
+					.Should()
+					.Be(Option.Some(VALUE+1)))
+			.Should().Throw<Exception>();
+
+			[Fact]
+			public void ShouldThrowExceptionWhenLeftIsSomeButRightIsNone() => new Func<Task>(() =>
+				Task.FromResult(Option.Some(VALUE))
+					.Should()
+					.Be(Option.None<int>()))
+			.Should().Throw<Exception>();
+
+			[Fact]
+			public void ShouldThrowExceptionWhenLeftIsNoneButRightIsSome() => new Func<Task>(() =>
+				Task.FromResult(Option.None<int>())
+					.Should()
+					.Be(Option.Some(VALUE)))
+			.Should().Throw<Exception>();
+		}
+
+		public class StringOptionChecks
+		{
+			private const string VALUE = "test";
+
+			[Fact]
+			public void ShouldNotThrowExceptionWhenBothSomeAndSameValues() => new Func<Task>(() =>
+				Task.FromResult(Option.Some(VALUE))
+					.Should()
+					.Be(Option.Some(VALUE)))
+			.Should().NotThrow();
+
+			[Fact]
+			public void ShouldNotThrowExceptionWhenBothNone() => new Func<Task>(() =>
+				Task.FromResult(Option.None<string>())
+					.Should()
+					.Be(Option.None<string>()))
+			.Should().NotThrow();
+
+			[Fact]
+			public void ShouldThrowExceptionWhenBothSomeButDifferentValues() => new Func<Task>(() =>
+				Task.FromResult(Option.Some(VALUE))
+					.Should()
+					.Be(Option.Some(VALUE + 1)))
+			.Should().Throw<Exception>();
+
+			[Fact]
+			public void ShouldThrowExceptionWhenLeftIsSomeButRightIsNone() => new Func<Task>(() =>
+				Task.FromResult(Option.Some(VALUE))
+					.Should()
+					.Be(Option.None<string>()))
+			.Should().Throw<Exception>();
+
+			[Fact]
+			public void ShouldThrowExceptionWhenLeftIsNoneButRightIsSome() => new Func<Task>(() =>
+				Task.FromResult(Option.None<string>())
+					.Should()
+					.Be(Option.Some(VALUE)))
+			.Should().Throw<Exception>();
+		}
+
+		public class EquatableClassOptionChecks
+		{
+			private const int VALUE = 1337;
+
+			[Fact]
+			public void ShouldNotThrowExceptionWhenBothSomeAndSameValues() => new Func<Task>(() =>
+				Task.FromResult(Option.Some(new EquatableClass(VALUE)))
+					.Should()
+					.Be(Option.Some(new EquatableClass(VALUE))))
+			.Should().NotThrow();
+
+			[Fact]
+			public void ShouldNotThrowExceptionWhenBothNone() => new Func<Task>(() =>
+				Task.FromResult(Option.None<string>())
+					.Should()
+					.Be(Option.None<string>()))
+			.Should().NotThrow();
+
+			[Fact]
+			public void ShouldThrowExceptionWhenBothSomeButDifferentValues() => new Func<Task>(() =>
+				Task.FromResult(Option.Some(new EquatableClass(VALUE)))
+					.Should()
+					.Be(Option.Some(new EquatableClass(VALUE + 1))))
+			.Should().Throw<Exception>();
+
+			[Fact]
+			public void ShouldThrowExceptionWhenLeftIsSomeButRightIsNone() => new Func<Task>(() =>
+				Task.FromResult(Option.Some(new EquatableClass(VALUE)))
+					.Should()
+					.Be(Option.None<EquatableClass>()))
+			.Should().Throw<Exception>();
+
+			[Fact]
+			public void ShouldThrowExceptionWhenLeftIsNoneButRightIsSome() => new Func<Task>(() =>
+				Task.FromResult(Option.None<EquatableClass>())
+					.Should()
+					.Be(Option.Some(new EquatableClass(VALUE))))
+			.Should().Throw<Exception>();
+
+			#region Models
+
+			private class EquatableClass : IEquatable<EquatableClass>
+			{
+				public EquatableClass(int value)
+				{
+					Value = value;
+				}
+
+				public int Value { get; }
+
+				public bool Equals(EquatableClass other)
+				{
+					if (other is null) return false;
+					if (ReferenceEquals(this, other)) return true;
+					return Value == other.Value;
+				}
+
+				public override bool Equals(object obj)
+				{
+					if (obj is null) return false;
+					if (ReferenceEquals(this, obj)) return true;
+					return obj.GetType() == GetType() && Equals((EquatableClass)obj);
+				}
+
+				public override int GetHashCode() => Value;
+				public static bool operator ==(EquatableClass left, EquatableClass right) => Equals(left, right);
+				public static bool operator !=(EquatableClass left, EquatableClass right) => !Equals(left, right);
+			}
+
+			#endregion
+		}
+	}
+}

--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.Tests/ResultTypeAssertionsExtensionsTests.cs
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.Tests/ResultTypeAssertionsExtensionsTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace Functional.Primitives.FluentAssertions.Tests
+{
+	public class ResultTypeAssertionsExtensionsTests
+	{
+		public class SuccessChecks
+		{
+			private const int VALUE = 3;
+
+			[Fact]
+			public void ShouldNotThrowException() => new Func<Task>(() =>
+				Task.FromResult(Result.Success<int, Exception>(VALUE))
+					.Should()
+					.BeSuccessful("an exception occurred"))
+			.Should().NotThrow();
+
+			[Fact]
+			public void ShouldNotThrowExceptionWhenAdditionalAssertionSucceeds() => new Func<Task>(() =>
+				Task.FromResult(Result.Success<int, Exception>(VALUE))
+					.Should()
+					.BeSuccessful()
+					.AndSuccessValue(value => value.Should().Be(VALUE)))
+			.Should().NotThrow();
+
+			[Fact]
+			public void ShouldThrowException() => new Func<Task>(() => Task.FromResult(Result.Failure<int, Exception>(new Exception())).Should().BeSuccessful()).Should().Throw<Exception>();
+		}
+
+		public class FailureChecks
+		{
+			private const string VALUE = "value";
+
+			[Fact]
+			public void ShouldNotThrowException() => new Func<Task>(() =>
+				Task.FromResult(Result.Failure<int, Exception>(new Exception(VALUE)))
+					.Should()
+					.BeFaulted())
+			.Should().NotThrow();
+
+			[Fact]
+			public void ShouldNotThrowExceptionWhenAdditionalAssertionSucceeds() => new Func<Task>(() =>
+				Task.FromResult(Result.Failure<int, Exception>(new Exception(VALUE)))
+					.Should()
+					.BeFaulted()
+					.AndFailureValue(failure => failure.Should().Match<Exception>(ex => ex.Message == VALUE)))
+			.Should().NotThrow();
+
+			[Fact]
+			public void ShouldThrowException() => new Func<Task>(() =>
+				Task.FromResult(Result.Success<int, Exception>(3))
+					.Should()
+					.BeFaulted())
+			.Should().Throw<Exception>();
+		}
+
+		public class EqualityChecks
+		{
+			[Fact]
+			public void ShouldNotThrowExceptionWhenBothSuccessAndBothHaveSameSuccessValues() => new Func<Task>(() =>
+				Task.FromResult(Result.Success<int, string>(1337))
+					.Should()
+					.Be(Result.Success<int, string>(1337)))
+			.Should().NotThrow();
+
+			[Fact]
+			public void ShouldNotThrowExceptionWhenBothFaultedAndBothHaveSameFailureValues() => new Func<Task>(() =>
+				Task.FromResult(Result.Failure<int, string>("error"))
+					.Should()
+					.Be(Result.Failure<int, string>("error")))
+			.Should().NotThrow();
+
+			[Fact]
+			public void ShouldThrowExceptionWhenBothSuccessButHaveDifferentSuccessValues() => new Func<Task>(() =>
+				Task.FromResult(Result.Success<int, string>(3))
+					.Should()
+					.Be(Result.Success<int, string>(4)))
+			.Should().Throw<Exception>();
+
+			[Fact]
+			public void ShouldThrowExceptionWhenBothFaultedButHaveDifferentFailureValues() => new Func<Task>(() =>
+				Task.FromResult(Result.Failure<int, string>("1"))
+					.Should()
+					.Be(Result.Failure<int, string>("2")))
+			.Should().Throw<Exception>();
+
+			[Fact]
+			public void ShouldThrowExceptionWhenLeftIsSuccessAndRightIsFaulted() => new Func<Task>(() =>
+				Task.FromResult(Result.Success<int, string>(3))
+					.Should()
+					.Be(Result.Failure<int, string>("e")))
+			.Should().Throw<Exception>();
+
+			[Fact]
+			public void ShouldThrowExceptionWhenLeftIsFaultedAndRightIsSuccess() => new Func<Task>(() =>
+				Task.FromResult(Result.Failure<int, string>("e"))
+					.Should()
+					.Be(Result.Success<int, string>(3)))
+			.Should().Throw<Exception>();
+		}
+	}
+}

--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/Extensions/OptionExtensions.cs
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/Extensions/OptionExtensions.cs
@@ -4,9 +4,7 @@ namespace Functional.Primitives.FluentAssertions.Extensions
 {
 	internal static class OptionExtensions
 	{
-		public static T GetValue<T>(this Option<T> source) => source.Match(value => value, () => throw new InvalidOperationException("Attempted to access value, but none exists!"));
-
 		public static T ValueUnsafe<T>(this Option<T> source)
-			=> source.Match(x => x, () => throw new InvalidOperationException("Must have value!"));
+			=> source.ThrowOnNone(() => throw new InvalidOperationException("Must have value!"));
 	}
 }

--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/Extensions/ResultExtensions.cs
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/Extensions/ResultExtensions.cs
@@ -5,7 +5,7 @@ namespace Functional.Primitives.FluentAssertions.Extensions
 	internal static class ResultExtensions
 	{
 		public static TSuccess SuccessUnsafe<TSuccess, TFailure>(this Result<TSuccess, TFailure> source)
-			=> source.Match(x => x, _ => throw new InvalidOperationException("Must be successful!"));
+			=> source.ThrowOnFailure(_ => throw new InvalidOperationException("Must be successful!"));
 
 		public static TFailure FailureUnsafe<TSuccess, TFailure>(this Result<TSuccess, TFailure> source)
 			=> source.Match(_ => throw new InvalidOperationException("Must be faulted!"), x => x);

--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.csproj
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.csproj
@@ -4,15 +4,15 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>This package provides extensions to FluentAssertions for the Functional.Primitives package.</Description>
-    <Authors>Ryan Marcotte</Authors>
+    <Authors>Ryan Marcotte + contributors</Authors>
     <Company />
     <Copyright>2019</Copyright>
     <RepositoryUrl></RepositoryUrl>
     <RepositoryType></RepositoryType>
     <PackageTags>functional, MSTest, MSTest2, NUnit, xUnit2, xUnit, TDD, Fluent, netcore, netstandard</PackageTags>
     <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.Utilities</PackageProjectUrl>
-    <Version>2.1.0</Version>
-    <PackageReleaseNotes>Add equality check assertions (.Should().Be(...)) for Option&lt;T&gt; and Result&lt;TSuccess, TFailure&gt;</PackageReleaseNotes>
+    <Version>2.2.0</Version>
+    <PackageReleaseNotes>Add extension methods for asserting Task&lt;Option&lt;T&gt;&gt; and Task&lt;Result&lt;TSuccess, TFailure&gt;&gt;</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 

--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/FunctionalPrimitiveAssertions.cs
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/FunctionalPrimitiveAssertions.cs
@@ -1,4 +1,6 @@
-﻿namespace Functional.Primitives.FluentAssertions
+﻿using System.Threading.Tasks;
+
+namespace Functional.Primitives.FluentAssertions
 {
 	/// <summary>
 	/// Defines additional fluent assertion gateways for types defined in Functional.Primitives namespace.
@@ -18,6 +20,18 @@
 		}
 
 		/// <summary>
+		/// Returns a <see cref="ResultTypeAssertions{TSuccess,TFailure}"/> object that can be used to assert the current <see cref="Result{TSuccess, TFailure}"/>.
+		/// </summary>
+		/// <typeparam name="TSuccess">The success object type.</typeparam>
+		/// <typeparam name="TFailure">The failure object type.</typeparam>
+		/// <param name="result">The result.</param>
+		/// <returns></returns>
+		public static async Task<ResultTypeAssertions<TSuccess, TFailure>> Should<TSuccess, TFailure>(this Task<Result<TSuccess, TFailure>> result)
+		{
+			return (await result).Should();
+		}
+
+		/// <summary>
 		/// Returns a <see cref="OptionTypeAssertions{T}"/> object that is used to assert the current <see cref="Option{T}"/>.
 		/// </summary>
 		/// <typeparam name="T">The option type.</typeparam>
@@ -26,6 +40,17 @@
 		public static OptionTypeAssertions<T> Should<T>(this Option<T> option)
 		{
 			return new OptionTypeAssertions<T>(option);
+		}
+
+		/// <summary>
+		/// Returns a <see cref="OptionTypeAssertions{T}"/> object that is used to assert the current <see cref="Option{T}"/>.
+		/// </summary>
+		/// <typeparam name="T">The option type.</typeparam>
+		/// <param name="option">The option.</param>
+		/// <returns></returns>
+		public static async Task<OptionTypeAssertions<T>> Should<T>(this Task<Option<T>> option)
+		{
+			return (await option).Should();
 		}
 	}
 }

--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/OptionTypeAssertionsExtensions.cs
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/OptionTypeAssertionsExtensions.cs
@@ -41,7 +41,7 @@ namespace Functional.Primitives.FluentAssertions
 		/// <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because"/>.</param>
 		/// <returns></returns>
 		public static async Task NotHaveValue<T>(this Task<OptionTypeAssertions<T>> source, string because = "", params object[] becauseArgs)
-			=> (await source).NotHaveValue();
+			=> (await source).NotHaveValue(because, becauseArgs);
 
 		/// <summary>
 		/// Invokes the provided action on the value of the option.

--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/OptionTypeAssertionsExtensions.cs
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/OptionTypeAssertionsExtensions.cs
@@ -1,0 +1,55 @@
+﻿using FluentAssertions;
+using FluentAssertions.Primitives;
+using System;
+using System.Threading.Tasks;
+
+namespace Functional.Primitives.FluentAssertions
+{
+	/// <summary>
+	/// A collection of extensions for <see cref="OptionTypeAssertions{T}"/>
+	/// </summary>
+	public static class OptionTypeAssertionsExtensions
+	{
+		/// <summary>
+		/// Verifies that the subject is equal to an expected value.
+		/// </summary>
+		/// <typeparam name="T">The contained type.</typeparam>
+		/// <param name="source">The source <see cref="OptionTypeAssertions{T}"/> task.</param>
+		/// <param name="expected">The expected value.</param>
+		/// <param name="because">Additional information for if the assertion fails.</param>
+		/// <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because"/>.</param>
+		/// <returns></returns>
+		public static async Task<AndConstraint<ObjectAssertions>> Be<T>(this Task<OptionTypeAssertions<T>> source, Option<T> expected, string because = "", params object[] becauseArgs)
+			=> (await source).Be(expected, because, becauseArgs);
+
+		/// <summary>
+		/// Verifies that the subject <see cref="Option{T}"/> holds a value.
+		/// </summary>
+		/// <typeparam name="T">The contained type.</typeparam>
+		/// <param name="source">The source <see cref="OptionTypeAssertions{T}"/> task.</param>
+		/// <param name="because">Additional information for if the assertion fails.</param>
+		/// <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because"/>.</param>
+		public static async Task<AndOptionValueConstraint<T>> HaveValue<T>(this Task<OptionTypeAssertions<T>> source, string because = "", params object[] becauseArgs)
+			=> (await source).HaveValue(because, becauseArgs);
+
+		/// <summary>
+		/// Verifies that the subject <see cref="Option{T}"/> does not hold a value.
+		/// </summary>
+		/// <typeparam name="T">The contained type.</typeparam>
+		/// <param name="source">The source <see cref="OptionTypeAssertions{T}"/> task.</param>
+		/// <param name="because">Additional information for if the assertion fails.</param>
+		/// <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because"/>.</param>
+		/// <returns></returns>
+		public static async Task NotHaveValue<T>(this Task<OptionTypeAssertions<T>> source, string because = "", params object[] becauseArgs)
+			=> (await source).NotHaveValue();
+
+		/// <summary>
+		/// Invokes the provided action on the value of the option.
+		/// </summary>
+		/// <typeparam name="T">The contained type.</typeparam>
+		/// <param name="source">The <see cref="AndOptionValueConstraint{T}"/> with the possible value to perform additional assertion actions on.</param>
+		/// <param name="action">The assertion action to perform on the option's value.</param>
+		public static async Task AndValue<T>(this Task<AndOptionValueConstraint<T>> source, Action<T> action)
+			=> action((await source).AndValue);
+	}
+}

--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/OptionTypeAssertions_Obsolete.cs
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/OptionTypeAssertions_Obsolete.cs
@@ -21,7 +21,7 @@ namespace Functional.Primitives.FluentAssertions
 			if (additionalAssertionAction == null) throw new ArgumentNullException(nameof(additionalAssertionAction));
 
 			HaveValue(because, becauseArgs);
-			additionalAssertionAction(_subject.GetValue());
+			additionalAssertionAction(_subject.ValueUnsafe());
 		}
 
 		/// <summary>
@@ -48,7 +48,7 @@ namespace Functional.Primitives.FluentAssertions
 		{
 			HaveValue(because, becauseArgs);
 
-			var value = _subject.GetValue();
+			var value = _subject.ValueUnsafe();
 			value.Should().BeEquivalentTo(
 				expectedValue,
 				config,

--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/ResultTypeAssertionsExtensions.cs
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/ResultTypeAssertionsExtensions.cs
@@ -1,0 +1,70 @@
+﻿using FluentAssertions;
+using FluentAssertions.Primitives;
+using System;
+using System.Threading.Tasks;
+
+namespace Functional.Primitives.FluentAssertions
+{
+	/// <summary>
+	/// A collection of extensions for <see cref="ResultTypeAssertions{TSuccess, TFailure}"/>
+	/// </summary>
+	public static class ResultTypeAssertionsExtensions
+	{
+		/// <summary>
+		/// Verifies that the subject is equal to an expected value.
+		/// </summary>
+		/// <typeparam name="TSuccess">The success value type.</typeparam>
+		/// <typeparam name="TFailure">The failure value type.</typeparam>
+		/// <param name="source">The source <see cref="ResultTypeAssertions{TSuccess, TFailure}"/> task.</param>
+		/// <param name="expected">The expected value.</param>
+		/// <param name="because">Additional information for if the assertion fails.</param>
+		/// <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because"/>.</param>
+		/// <returns></returns>
+		public static async Task<AndConstraint<ObjectAssertions>> Be<TSuccess, TFailure>(this Task<ResultTypeAssertions<TSuccess, TFailure>> source, Result<TSuccess, TFailure> expected, string because = "", params object[] becauseArgs)
+			=> (await source).Be(expected, because, becauseArgs);
+
+		/// <summary>
+		/// Verifies that the subject <see cref="Result{TSuccess, TFailure}"/> holds a successful result.
+		/// </summary>
+		/// <typeparam name="TSuccess">The success value type.</typeparam>
+		/// <typeparam name="TFailure">The failure value type.</typeparam>
+		/// <param name="source">The source <see cref="ResultTypeAssertions{TSuccess, TFailure}"/> task.</param>
+		/// <param name="because">Additional information for if the assertion fails.</param>
+		/// <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because"/>.</param>
+		/// <returns></returns>
+		public static async Task<AndResultSuccessConstraint<TSuccess>> BeSuccessful<TSuccess, TFailure>(this Task<ResultTypeAssertions<TSuccess, TFailure>> source, string because = "", params object[] becauseArgs)
+			=> (await source).BeSuccessful(because, becauseArgs);
+
+		/// <summary>
+		/// Verifies that the subject <see cref="Result{TSuccess, TFailure}"/> holds a faulted result.
+		/// </summary>
+		/// <typeparam name="TSuccess">The success value type.</typeparam>
+		/// <typeparam name="TFailure">The failure value type.</typeparam>
+		/// <param name="source">The source <see cref="ResultTypeAssertions{TSuccess, TFailure}"/> task.</param>
+		/// <param name="because">Additional information for if the assertion fails.</param>
+		/// <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because"/>.</param>
+		/// <returns></returns>
+		public static async Task<AndResultFailureConstraint<TFailure>> BeFaulted<TSuccess, TFailure>(this Task<ResultTypeAssertions<TSuccess, TFailure>> source, string because = "", params object[] becauseArgs)
+			=> (await source).BeFaulted(because, becauseArgs);
+
+		/// <summary>
+		/// Invokes the provided action on the succesful value of the result.
+		/// </summary>
+		/// <typeparam name="TSuccess">The success value type.</typeparam>
+		/// <param name="source">The <see cref="ResultTypeAssertions{TSuccess, TFailure}"/> task with the success value to perform additional assertion actions on.</param>
+		/// <param name="action">The assertion action to perform on the result's success value.</param>
+		/// <returns></returns>
+		public static async Task AndSuccessValue<TSuccess>(this Task<AndResultSuccessConstraint<TSuccess>> source, Action<TSuccess> action)
+			=> action((await source).AndSuccessValue);
+
+		/// <summary>
+		/// Invokes the provided action on the failure value of the result.
+		/// </summary>
+		/// <typeparam name="TFailure">The failure value type.</typeparam>
+		/// <param name="source">The <see cref="ResultTypeAssertions{TSuccess, TFailure}"/> task with the failure value to perform additional assertion actions on.</param>
+		/// <param name="action">The assertion action to perform on the result's failure value.</param>
+		/// <returns></returns>
+		public static async Task AndFailureValue<TFailure>(this Task<AndResultFailureConstraint<TFailure>> source, Action<TFailure> action)
+			=> action((await source).AndFailureValue);
+	}
+}

--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/ResultTypeAssertionsExtensions.cs
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/ResultTypeAssertionsExtensions.cs
@@ -48,7 +48,7 @@ namespace Functional.Primitives.FluentAssertions
 			=> (await source).BeFaulted(because, becauseArgs);
 
 		/// <summary>
-		/// Invokes the provided action on the succesful value of the result.
+		/// Invokes the provided action on the successful value of the result.
 		/// </summary>
 		/// <typeparam name="TSuccess">The success value type.</typeparam>
 		/// <param name="source">The <see cref="ResultTypeAssertions{TSuccess, TFailure}"/> task with the success value to perform additional assertion actions on.</param>


### PR DESCRIPTION
This PR adds extension methods that provide assertions for both `Task<Option<T>>` and `Task<Result<TSuccess, TFailure>>`.

Example `Task<Option<T>>` assertion:
```C#
Task.FromResult(Option.Some(VALUE))
    .Should()
    .HaveValue()
    .AndValue(v => v.Should().Be(VALUE)))
```

Example `Task<Result<TSuccess, TFailure>>` assertion:
```C#
Task.FromResult(Result.Failure<int, Exception>(new Exception(VALUE)))
    .Should()
    .BeFaulted()
    .AndFailureValue(e => e.Message.Should().Be("Exception")))
```