### PR TITLE
Updates the public extensions to use the `Functional` namespace.

### DIFF
--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.csproj
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.csproj
@@ -11,7 +11,7 @@
     <RepositoryType></RepositoryType>
     <PackageTags>functional, MSTest, MSTest2, NUnit, xUnit2, xUnit, TDD, Fluent, netcore, netstandard</PackageTags>
     <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.Utilities</PackageProjectUrl>
-    <Version>3.0.0</Version>
+    <Version>3.0.1</Version>
     <PackageReleaseNotes>Deletes Obsolete methods and help fix method discoverability issue</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>

--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/OptionTypeAssertionsExtensions.cs
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/OptionTypeAssertionsExtensions.cs
@@ -1,9 +1,10 @@
 ﻿using FluentAssertions;
 using FluentAssertions.Primitives;
+using Functional.Primitives.FluentAssertions;
 using System;
 using System.Threading.Tasks;
 
-namespace Functional.Primitives.FluentAssertions
+namespace Functional
 {
 	/// <summary>
 	/// A collection of extensions for <see cref="OptionTypeAssertions{T}"/>

--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/OptionTypeAssertionsExtensions.cs
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/OptionTypeAssertionsExtensions.cs
@@ -4,6 +4,7 @@ using Functional.Primitives.FluentAssertions;
 using System;
 using System.Threading.Tasks;
 
+// ReSharper disable once CheckNamespace (ease of discoverability)
 namespace Functional
 {
 	/// <summary>

--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/ResultTypeAssertionsExtensions.cs
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/ResultTypeAssertionsExtensions.cs
@@ -1,9 +1,10 @@
 ﻿using FluentAssertions;
 using FluentAssertions.Primitives;
+using Functional.Primitives.FluentAssertions;
 using System;
 using System.Threading.Tasks;
 
-namespace Functional.Primitives.FluentAssertions
+namespace Functional
 {
 	/// <summary>
 	/// A collection of extensions for <see cref="ResultTypeAssertions{TSuccess, TFailure}"/>

--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/ResultTypeAssertionsExtensions.cs
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions/ResultTypeAssertionsExtensions.cs
@@ -4,6 +4,7 @@ using Functional.Primitives.FluentAssertions;
 using System;
 using System.Threading.Tasks;
 
+// ReSharper disable once CheckNamespace (ease of discoverability)
 namespace Functional
 {
 	/// <summary>

--- a/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/AndUnionValueConstraintExtensions.cs
+++ b/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/AndUnionValueConstraintExtensions.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
+// ReSharper disable once CheckNamespace (ease of discoverability)
 namespace Functional
 {
 	/// <summary>

--- a/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/AndUnionValueConstraintExtensions.cs
+++ b/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/AndUnionValueConstraintExtensions.cs
@@ -1,7 +1,8 @@
-﻿using System;
+﻿using Functional.Unions.FluentAssertions;
+using System;
 using System.Threading.Tasks;
 
-namespace Functional.Unions.FluentAssertions
+namespace Functional
 {
 	/// <summary>
 	/// Extension methods for the <see cref="AndUnionValueConstraint{T}"/> class.

--- a/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions.csproj
+++ b/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Justin Cooney + contributors</Authors>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Description>This package provides extensions to FluentAssertions for the Functional.Unions package.</Description>
     <Copyright>2020</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions2.cs
+++ b/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions2.cs
@@ -1,8 +1,9 @@
 ﻿using FluentAssertions;
 using FluentAssertions.Primitives;
+using Functional.Unions.FluentAssertions;
 using System.Threading.Tasks;
 
-namespace Functional.Unions.FluentAssertions
+namespace Functional
 {
 	/// <summary>
 	/// Extension methods for the <see cref="UnionValueTypeAssertions{TUnionType,TUnionDefinition,TOne,TTwo}"/> class.

--- a/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions2.cs
+++ b/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions2.cs
@@ -3,6 +3,7 @@ using FluentAssertions.Primitives;
 using Functional.Unions.FluentAssertions;
 using System.Threading.Tasks;
 
+// ReSharper disable once CheckNamespace (ease of discoverability)
 namespace Functional
 {
 	/// <summary>

--- a/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions3.cs
+++ b/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions3.cs
@@ -1,8 +1,9 @@
 ﻿using FluentAssertions;
 using FluentAssertions.Primitives;
+using Functional.Unions.FluentAssertions;
 using System.Threading.Tasks;
 
-namespace Functional.Unions.FluentAssertions
+namespace Functional
 {
 	/// <summary>
 	/// Extension methods for the <see cref="UnionValueTypeAssertions{TUnionType,TUnionDefinition,TOne,TTwo,TThree}"/> class.

--- a/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions3.cs
+++ b/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions3.cs
@@ -3,6 +3,7 @@ using FluentAssertions.Primitives;
 using Functional.Unions.FluentAssertions;
 using System.Threading.Tasks;
 
+// ReSharper disable once CheckNamespace (ease of discoverability)
 namespace Functional
 {
 	/// <summary>

--- a/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions4.cs
+++ b/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions4.cs
@@ -1,8 +1,9 @@
 ﻿using FluentAssertions;
 using FluentAssertions.Primitives;
+using Functional.Unions.FluentAssertions;
 using System.Threading.Tasks;
 
-namespace Functional.Unions.FluentAssertions
+namespace Functional
 {
 	/// <summary>
 	/// Extension methods for the <see cref="UnionValueTypeAssertions{TUnionType,TUnionDefinition,TOne,TTwo,TThree,TFour}"/> class.

--- a/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions4.cs
+++ b/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions4.cs
@@ -3,6 +3,7 @@ using FluentAssertions.Primitives;
 using Functional.Unions.FluentAssertions;
 using System.Threading.Tasks;
 
+// ReSharper disable once CheckNamespace (ease of discoverability)
 namespace Functional
 {
 	/// <summary>

--- a/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions5.cs
+++ b/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions5.cs
@@ -3,6 +3,7 @@ using FluentAssertions.Primitives;
 using Functional.Unions.FluentAssertions;
 using System.Threading.Tasks;
 
+// ReSharper disable once CheckNamespace (ease of discoverability)
 namespace Functional
 {
 	/// <summary>

--- a/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions5.cs
+++ b/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions5.cs
@@ -1,8 +1,9 @@
 ﻿using FluentAssertions;
 using FluentAssertions.Primitives;
+using Functional.Unions.FluentAssertions;
 using System.Threading.Tasks;
 
-namespace Functional.Unions.FluentAssertions
+namespace Functional
 {
 	/// <summary>
 	/// Extension methods for the <see cref="UnionValueTypeAssertions{TUnionType,TUnionDefinition,TOne,TTwo,TThree,TFour,TFive}"/> class.

--- a/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions6.cs
+++ b/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions6.cs
@@ -1,8 +1,9 @@
 ﻿using FluentAssertions;
 using FluentAssertions.Primitives;
+using Functional.Unions.FluentAssertions;
 using System.Threading.Tasks;
 
-namespace Functional.Unions.FluentAssertions
+namespace Functional
 {
 	/// <summary>
 	/// Extension methods for the <see cref="UnionValueTypeAssertions{TUnionType,TUnionDefinition,TOne,TTwo,TThree,TFour,TFive,TSix}"/> class.

--- a/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions6.cs
+++ b/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions6.cs
@@ -3,6 +3,7 @@ using FluentAssertions.Primitives;
 using Functional.Unions.FluentAssertions;
 using System.Threading.Tasks;
 
+// ReSharper disable once CheckNamespace (ease of discoverability)
 namespace Functional
 {
 	/// <summary>

--- a/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions7.cs
+++ b/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions7.cs
@@ -1,8 +1,9 @@
 ﻿using FluentAssertions;
 using FluentAssertions.Primitives;
+using Functional.Unions.FluentAssertions;
 using System.Threading.Tasks;
 
-namespace Functional.Unions.FluentAssertions
+namespace Functional
 {
 	/// <summary>
 	/// Extension methods for the <see cref="UnionValueTypeAssertions{TUnionType,TUnionDefinition,TOne,TTwo,TThree,TFour,TFive,TSix,TSeven}"/> class.

--- a/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions7.cs
+++ b/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions7.cs
@@ -3,6 +3,7 @@ using FluentAssertions.Primitives;
 using Functional.Unions.FluentAssertions;
 using System.Threading.Tasks;
 
+// ReSharper disable once CheckNamespace (ease of discoverability)
 namespace Functional
 {
 	/// <summary>

--- a/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions8.cs
+++ b/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions8.cs
@@ -1,8 +1,9 @@
 ﻿using FluentAssertions;
 using FluentAssertions.Primitives;
+using Functional.Unions.FluentAssertions;
 using System.Threading.Tasks;
 
-namespace Functional.Unions.FluentAssertions
+namespace Functional
 {
 	/// <summary>
 	/// Extension methods for the <see cref="UnionValueTypeAssertions{TUnionType,TUnionDefinition,TOne,TTwo,TThree,TFour,TFive,TSix,TSeven,TEight}"/> class.

--- a/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions8.cs
+++ b/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions/UnionValueTypeAssertionsExtensions8.cs
@@ -3,6 +3,7 @@ using FluentAssertions.Primitives;
 using Functional.Unions.FluentAssertions;
 using System.Threading.Tasks;
 
+// ReSharper disable once CheckNamespace (ease of discoverability)
 namespace Functional
 {
 	/// <summary>


### PR DESCRIPTION
I should have noticed this earlier, but with the move to the `Functional` namespace all public extensions need to have their namespaces changed as well.