### PR TITLE
Add context for better error messages

### DIFF
--- a/src/Functional.Primitives.FluentAssertions.Tests/OptionTypeAssertionsTests.cs
+++ b/src/Functional.Primitives.FluentAssertions.Tests/OptionTypeAssertionsTests.cs
@@ -32,13 +32,24 @@ namespace Functional.Primitives.FluentAssertions.Tests
 			}).Should().NotThrow();
 
 			[Fact]
-			public void ShouldThrowException() => new Action(() =>
+			public void ShouldThrowExceptionWithNameOfVariable()
 			{
-				Option.None<int>()
+				var localVariable = Option.None<int>();
+				new Action(() => localVariable.Should().HaveValue())
 					.Should()
-					.HaveValue();
+					.Throw<Exception>()
+					.And.Message.Should().ContainAll(nameof(localVariable));
+			}
 
-			}).Should().Throw<Exception>();
+			[Fact]
+			public void ShouldThrowExceptionWithNameOfClassMember()
+			{
+				var envelope = new OptionEnvelope<int>(Option.None<int>());
+				new Action(() => envelope.Data.Should().HaveValue())
+					.Should()
+					.Throw<Exception>()
+					.And.Message.Should().ContainAll(nameof(envelope), nameof(OptionEnvelope<int>.Data));
+			}
 		}
 
 		public class NoValueChecks
@@ -47,7 +58,24 @@ namespace Functional.Primitives.FluentAssertions.Tests
 			public void ShouldNotThrowException() => new Action(() => Option.None<int>().Should().NotHaveValue()).Should().NotThrow();
 
 			[Fact]
-			public void ShouldThrowException() => new Action(() => Option.Some(3).Should().NotHaveValue()).Should().Throw<Exception>();
+			public void ShouldThrowExceptionWithNameOfVariable()
+			{
+				var localVariable = Option.Some(3);
+				new Action(() => localVariable.Should().NotHaveValue())
+					.Should()
+					.Throw<Exception>()
+					.And.Message.Should().Contain(nameof(localVariable));
+			}
+
+			[Fact]
+			public void ShouldThrowExceptionWithNameOfClassMember()
+			{
+				var envelope = new OptionEnvelope<int>(Option.Some(15));
+				new Action(() => envelope.Data.Should().NotHaveValue())
+					.Should()
+					.Throw<Exception>()
+					.And.Message.Should().ContainAll(nameof(envelope), nameof(OptionEnvelope<int>.Data));
+			}
 		}
 
 		public class IntegerOptionChecks
@@ -71,28 +99,64 @@ namespace Functional.Primitives.FluentAssertions.Tests
 			}).Should().NotThrow();
 
 			[Fact]
-			public void ShouldThrowExceptionWhenBothSomeButDifferentValues() => new Action(() =>
+			public void ShouldThrowExceptionWithNameOfVariableWhenBothSomeButDifferentValues()
 			{
-				Option.Some(VALUE)
+				var localVariable = Option.Some(VALUE);
+				new Action(() => localVariable.Should().Be(Option.Some(VALUE + 1)))
 					.Should()
-					.Be(Option.Some(VALUE+1));
-			}).Should().Throw<Exception>();
+					.Throw<Exception>()
+					.And.Message.Should().Contain(nameof(localVariable));
+			}
 
 			[Fact]
-			public void ShouldThrowExceptionWhenLeftIsSomeButRightIsNone() => new Action(() =>
+			public void ShouldThrowExceptionWithNameOfClassMemberWhenBothSomeButDifferentValues()
 			{
-				Option.Some(VALUE)
+				var envelope = new OptionEnvelope<int>(Option.Some(VALUE));
+				new Action(() => envelope.Data.Should().Be(Option.Some(VALUE + 1)))
 					.Should()
-					.Be(Option.None<int>());
-			}).Should().Throw<Exception>();
+					.Throw<Exception>()
+					.And.Message.Should().ContainAll(nameof(envelope), nameof(OptionEnvelope<int>.Data));
+			}
 
 			[Fact]
-			public void ShouldThrowExceptionWhenLeftIsNoneButRightIsSome() => new Action(() =>
+			public void ShouldThrowExceptionWithNameOfVariableWhenLeftIsSomeButRightIsNone()
 			{
-				Option.None<int>()
+				var localVariable = Option.Some(VALUE);
+				new Action(() => localVariable.Should().Be(Option.None<int>()))
 					.Should()
-					.Be(Option.Some(VALUE));
-			}).Should().Throw<Exception>();
+					.Throw<Exception>()
+					.And.Message.Should().Contain(nameof(localVariable));
+			}
+
+			[Fact]
+			public void ShouldThrowExceptionWithNameOfClassMemberWhenLeftIsSomeButRightIsNone()
+			{
+				var envelope = new OptionEnvelope<int>(Option.Some(VALUE));
+				new Action(() => envelope.Data.Should().Be(Option.None<int>()))
+					.Should()
+					.Throw<Exception>()
+					.And.Message.Should().ContainAll(nameof(envelope), nameof(OptionEnvelope<int>.Data));
+			}
+
+			[Fact]
+			public void ShouldThrowExceptionWithNameOfVariableWhenLeftIsNoneButRightIsSome()
+			{
+				var localVariable = Option.None<int>();
+				new Action(() => localVariable.Should().Be(Option.Some(VALUE)))
+					.Should()
+					.Throw<Exception>()
+					.And.Message.Should().Contain(nameof(localVariable));
+			}
+
+			[Fact]
+			public void ShouldThrowExceptionWithNameOfClassMemberWhenLeftIsNoneButRightIsSome()
+			{
+				var envelope = new OptionEnvelope<int>(Option.None<int>());
+				new Action(() => envelope.Data.Should().Be(Option.Some(VALUE)))
+					.Should()
+					.Throw<Exception>()
+					.And.Message.Should().Contain(nameof(envelope), nameof(OptionEnvelope<int>.Data));
+			}
 		}
 
 		public class StringOptionChecks
@@ -116,28 +180,64 @@ namespace Functional.Primitives.FluentAssertions.Tests
 			}).Should().NotThrow();
 
 			[Fact]
-			public void ShouldThrowExceptionWhenBothSomeButDifferentValues() => new Action(() =>
+			public void ShouldThrowExceptionWithNameOfVariableWhenBothSomeButDifferentValues()
 			{
-				Option.Some(VALUE)
+				var localVariable = Option.Some(VALUE);
+				new Action(() => localVariable.Should().Be(Option.Some(VALUE + 1)))
 					.Should()
-					.Be(Option.Some(VALUE + 1));
-			}).Should().Throw<Exception>();
+					.Throw<Exception>()
+					.And.Message.Should().Contain(nameof(localVariable));
+			}
 
 			[Fact]
-			public void ShouldThrowExceptionWhenLeftIsSomeButRightIsNone() => new Action(() =>
+			public void ShouldThrowExceptionWithNameOfClassMemberWhenBothSomeButDifferentValues()
 			{
-				Option.Some(VALUE)
+				var envelope = new OptionEnvelope<string>(Option.Some(VALUE));
+				new Action(() => envelope.Should().Be(Option.Some(VALUE + 1)))
 					.Should()
-					.Be(Option.None<string>());
-			}).Should().Throw<Exception>();
+					.Throw<Exception>()
+					.And.Message.Should().ContainAll(nameof(envelope), nameof(OptionEnvelope<string>.Data));
+			}
 
 			[Fact]
-			public void ShouldThrowExceptionWhenLeftIsNoneButRightIsSome() => new Action(() =>
+			public void ShouldThrowExceptionWithNameOfVariableWhenLeftIsSomeButRightIsNone()
 			{
-				Option.None<string>()
+				var localVariable = Option.Some(VALUE);
+				new Action(() => localVariable.Should().Be(Option.None<string>()))
 					.Should()
-					.Be(Option.Some(VALUE));
-			}).Should().Throw<Exception>();
+					.Throw<Exception>()
+					.And.Message.Should().Contain(nameof(localVariable));
+			}
+
+			[Fact]
+			public void ShouldThrowExceptionWithNameOfClassMemberWhenLeftIsSomeButRightIsNone()
+			{
+				var envelope = new OptionEnvelope<string>(Option.Some(VALUE));
+				new Action(() => envelope.Should().Be(Option.None<string>()))
+					.Should()
+					.Throw<Exception>()
+					.And.Message.Should().ContainAll(nameof(envelope), nameof(OptionEnvelope<string>.Data));
+			}
+
+			[Fact]
+			public void ShouldThrowExceptionWithNameOfVariableWhenLeftIsNoneButRightIsSome()
+			{
+				var localVariable = Option.None<string>();
+				new Action(() => localVariable.Should().Be(Option.Some(VALUE)))
+					.Should()
+					.Throw<Exception>()
+					.And.Message.Should().Contain(nameof(localVariable));
+			}
+
+			[Fact]
+			public void ShouldThrowExceptionWithNameOfClassMemberWhenLeftIsNoneButRightIsSome()
+			{
+				var envelope = new OptionEnvelope<string>(Option.None<string>());
+				new Action(() => envelope.Should().Be(Option.Some(VALUE)))
+					.Should()
+					.Throw<Exception>()
+					.And.Message.Should().ContainAll(nameof(envelope), nameof(OptionEnvelope<string>.Data));
+			}
 		}
 
 		public class EquatableClassOptionChecks
@@ -161,28 +261,64 @@ namespace Functional.Primitives.FluentAssertions.Tests
 			}).Should().NotThrow();
 
 			[Fact]
-			public void ShouldThrowExceptionWhenBothSomeButDifferentValues() => new Action(() =>
+			public void ShouldThrowExceptionWithNameOfLocalVariableWhenBothSomeButDifferentValues()
 			{
-				Option.Some(new EquatableClass(VALUE))
+				var localVariable = Option.Some(new EquatableClass(VALUE));
+				new Action(() => localVariable.Should().Be(Option.Some(new EquatableClass(VALUE + 1))))
 					.Should()
-					.Be(Option.Some(new EquatableClass(VALUE + 1)));
-			}).Should().Throw<Exception>();
+					.Throw<Exception>()
+					.And.Message.Should().Contain(nameof(localVariable));
+			}
 
 			[Fact]
-			public void ShouldThrowExceptionWhenLeftIsSomeButRightIsNone() => new Action(() =>
+			public void ShouldThrowExceptionWithNameOfClassMemberWhenBothSomeButDifferentValues()
 			{
-				Option.Some(new EquatableClass(VALUE))
+				var envelope = new OptionEnvelope<EquatableClass>(Option.Some(new EquatableClass(VALUE)));
+				new Action(() => envelope.Data.Should().Be(Option.Some(new EquatableClass(VALUE + 1))))
 					.Should()
-					.Be(Option.None<EquatableClass>());
-			}).Should().Throw<Exception>();
+					.Throw<Exception>()
+					.And.Message.Should().ContainAll(nameof(envelope), nameof(OptionEnvelope<EquatableClass>.Data));
+			}
 
 			[Fact]
-			public void ShouldThrowExceptionWhenLeftIsNoneButRightIsSome() => new Action(() =>
+			public void ShouldThrowExceptionWithNameOfLocalVariableWhenLeftIsSomeButRightIsNone()
 			{
-				Option.None<EquatableClass>()
+				var localVariable = Option.Some(new EquatableClass(VALUE));
+				new Action(() => localVariable.Should().Be(Option.None<EquatableClass>()))
 					.Should()
-					.Be(Option.Some(new EquatableClass(VALUE)));
-			}).Should().Throw<Exception>();
+					.Throw<Exception>()
+					.And.Message.Should().Contain(nameof(localVariable));
+			}
+
+			[Fact]
+			public void ShouldThrowExceptionWithNameOfClassMemberWhenLeftIsSomeButRightIsNone()
+			{
+				var envelope = new OptionEnvelope<EquatableClass>(Option.Some(new EquatableClass(VALUE)));
+				new Action(() => envelope.Data.Should().Be(Option.None<EquatableClass>()))
+					.Should()
+					.Throw<Exception>()
+					.And.Message.Should().ContainAll(nameof(envelope), nameof(OptionEnvelope<EquatableClass>.Data));
+			}
+
+			[Fact]
+			public void ShouldThrowExceptionWithNameOfLocalVariableWhenLeftIsNoneButRightIsSome()
+			{
+				var localVariable = Option.None<EquatableClass>();
+				new Action(() => localVariable.Should().Be(Option.Some(new EquatableClass(VALUE))))
+					.Should()
+					.Throw<Exception>()
+					.And.Message.Should().Contain(nameof(localVariable));
+			}
+
+			[Fact]
+			public void ShouldThrowExceptionWithNameOfClassMemberWhenLeftIsNoneButRightIsSome()
+			{
+				var envelope = new OptionEnvelope<EquatableClass>(Option.None<EquatableClass>());
+				new Action(() => envelope.Data.Should().Be(Option.Some(new EquatableClass(VALUE))))
+					.Should()
+					.Throw<Exception>()
+					.And.Message.Should().ContainAll(nameof(envelope), nameof(OptionEnvelope<EquatableClass>.Data));
+			}
 
 			#region Models
 
@@ -215,6 +351,16 @@ namespace Functional.Primitives.FluentAssertions.Tests
 			}
 
 			#endregion
+		}
+
+		private class OptionEnvelope<T>
+		{
+			public OptionEnvelope(Option<T> data)
+			{
+				Data = data;
+			}
+
+			public Option<T> Data { get; }
 		}
 	}
 }

--- a/src/Functional.Primitives.FluentAssertions.Tests/ResultTypeAssertionsTests.cs
+++ b/src/Functional.Primitives.FluentAssertions.Tests/ResultTypeAssertionsTests.cs
@@ -32,7 +32,24 @@ namespace Functional.Primitives.FluentAssertions.Tests
 			}).Should().NotThrow();
 
 			[Fact]
-			public void ShouldThrowException() => new Action(() => Result.Failure<int, Exception>(new Exception()).Should().BeSuccessful()).Should().Throw<Exception>();
+			public void ShouldThrowExceptionWithNameOfLocalVariable()
+			{
+				var localVariable = Result.Failure<int, Exception>(new Exception());
+				new Action(() => localVariable.Should().BeSuccessful())
+					.Should()
+					.Throw<Exception>()
+					.And.Message.Should().Contain(nameof(localVariable));
+			}
+
+			[Fact]
+			public void ShouldThrowExceptionWithNameOfClassMember()
+			{
+				var envelope = new ResultEnvelope<int, Exception>(Result.Failure<int, Exception>(new Exception()));
+				new Action(() => envelope.Data.Should().BeSuccessful())
+					.Should()
+					.Throw<Exception>()
+					.And.Message.Should().ContainAll(nameof(envelope), nameof(ResultEnvelope<int, Exception>.Data));
+			}
 		}
 
 		public class FailureChecks
@@ -61,13 +78,24 @@ namespace Functional.Primitives.FluentAssertions.Tests
 			}).Should().NotThrow();
 
 			[Fact]
-			public void ShouldThrowException() => new Action(() =>
+			public void ShouldThrowExceptionWithNameOfLocalVariable()
 			{
-				Result.Success<int, Exception>(3)
+				var localVariable = Result.Success<int, Exception>(3);
+				new Action(() => localVariable.Should().BeFaulted())
 					.Should()
-					.BeFaulted();
+					.Throw<Exception>()
+					.And.Message.Should().Contain(nameof(localVariable));
+			}
 
-			}).Should().Throw<Exception>();
+			[Fact]
+			public void ShouldThrowExceptionWithNameOfClassMember()
+			{
+				var envelope = new ResultEnvelope<int, Exception>(Result.Success<int, Exception>(3));
+				new Action(() => envelope.Data.Should().BeFaulted())
+					.Should()
+					.Throw<Exception>()
+					.And.Message.Should().Contain(nameof(envelope), nameof(ResultEnvelope<int, Exception>.Data));
+			}
 		}
 
 		public class EqualityChecks
@@ -89,40 +117,94 @@ namespace Functional.Primitives.FluentAssertions.Tests
 			}).Should().NotThrow();
 
 			[Fact]
-			public void ShouldThrowExceptionWhenBothSuccessButHaveDifferentSuccessValues() => new Action(() =>
+			public void ShouldThrowExceptionWithNameOfLocalVariableWhenBothSuccessButHaveDifferentSuccessValues()
 			{
-				Result.Success<int, string>(3)
+				var localVariable = Result.Success<int, string>(3);
+				new Action(() => localVariable.Should().Be(Result.Success<int, string>(4)))
 					.Should()
-					.Be(Result.Success<int, string>(4));
-
-			}).Should().Throw<Exception>();
+					.Throw<Exception>()
+					.And.Message.Should().Contain(nameof(localVariable));
+			}
 
 			[Fact]
-			public void ShouldThrowExceptionWhenBothFaultedButHaveDifferentFailureValues() => new Action(() =>
+			public void ShouldThrowExceptionWithNameOfClassMemberWhenBothSuccessButHaveDifferentSuccessValues()
 			{
-				Result.Failure<int, string>("1")
+				var envelope = new ResultEnvelope<int, string>(Result.Success<int, string>(3));
+				new Action(() => envelope.Data.Should().Be(Result.Success<int, string>(4)))
 					.Should()
-					.Be(Result.Failure<int, string>("2"));
-
-			}).Should().Throw<Exception>();
+					.Throw<Exception>()
+					.And.Message.Should().ContainAll(nameof(envelope), nameof(ResultEnvelope<int, Exception>.Data));
+			}
 
 			[Fact]
-			public void ShouldThrowExceptionWhenLeftIsSuccessAndRightIsFaulted() => new Action(() =>
+			public void ShouldThrowExceptionWithNameOfLocalVariableWhenBothFaultedButHaveDifferentFailureValues()
 			{
-				Result.Success<int, string>(3)
+				var localVariable = Result.Failure<int, string>("1");
+				new Action(() => localVariable.Should().Be(Result.Failure<int, string>("2")))
 					.Should()
-					.Be(Result.Failure<int, string>("e"));
-
-			}).Should().Throw<Exception>();
+					.Throw<Exception>()
+					.And.Message.Should().Contain(nameof(localVariable));
+			}
 
 			[Fact]
-			public void ShouldThrowExceptionWhenLeftIsFaultedAndRightIsSuccess() => new Action(() =>
+			public void ShouldThrowExceptionWithNameOfClassMemberWhenBothFaultedButHaveDifferentFailureValues()
 			{
-				Result.Failure<int, string>("e")
+				var envelope = new ResultEnvelope<int, string>(Result.Failure<int, string>("1"));
+				new Action(() => envelope.Data.Should().Be(Result.Failure<int, string>("2")))
 					.Should()
-					.Be(Result.Success<int, string>(3));
+					.Throw<Exception>()
+					.And.Message.Should().Contain(nameof(envelope), nameof(ResultEnvelope<int, string>.Data));
+			}
 
-			}).Should().Throw<Exception>();
+			[Fact]
+			public void ShouldThrowExceptionWithNameOfLocalVariableWhenLeftIsSuccessAndRightIsFaulted()
+			{
+				var localVariable = Result.Success<int, string>(3);
+				new Action(() => localVariable.Should().Be(Result.Failure<int, string>("e")))
+					.Should()
+					.Throw<Exception>()
+					.And.Message.Should().Contain(nameof(localVariable));
+			}
+
+			[Fact]
+			public void ShouldThrowExceptionWithNameOfClassMemberWhenLeftIsSuccessAndRightIsFaulted()
+			{
+				var envelope = new ResultEnvelope<int, string>(Result.Success<int, string>(3));
+				new Action(() => envelope.Data.Should().Be(Result.Failure<int, string>("e")))
+					.Should()
+					.Throw<Exception>()
+					.And.Message.Should().Contain(nameof(envelope), nameof(ResultEnvelope<int, string>.Data));
+			}
+
+			[Fact]
+			public void ShouldThrowExceptionWithNameOfLocalVariableWhenLeftIsFaultedAndRightIsSuccess()
+			{
+				var localVariable = Result.Failure<int, string>("e");
+				new Action(() => localVariable.Should().Be(Result.Success<int, string>(3)))
+					.Should()
+					.Throw<Exception>()
+					.And.Message.Should().Contain(nameof(localVariable));
+			}
+
+			[Fact]
+			public void ShouldThrowExceptionWithNameOfClassMemberWhenLeftIsFaultedAndRightIsSuccess()
+			{
+				var envelope = new ResultEnvelope<int, string>(Result.Failure<int, string>("e"));
+				new Action(() => envelope.Data.Should().Be(Result.Success<int, string>(3)))
+					.Should()
+					.Throw<Exception>()
+					.And.Message.Should().Contain(nameof(envelope), nameof(ResultEnvelope<int, string>.Data));
+			}
+		}
+
+		private class ResultEnvelope<TSuccess, TFailure>
+		{
+			public ResultEnvelope(Result<TSuccess, TFailure> data)
+			{
+				Data = data;
+			}
+
+			public Result<TSuccess, TFailure> Data { get; }
 		}
 	}
 }

--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.csproj
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.csproj
@@ -11,8 +11,8 @@
     <RepositoryType></RepositoryType>
     <PackageTags>functional, MSTest, MSTest2, NUnit, xUnit2, xUnit, TDD, Fluent, netcore, netstandard</PackageTags>
     <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.Utilities</PackageProjectUrl>
-    <Version>3.0.1</Version>
-    <PackageReleaseNotes>Deletes Obsolete methods and help fix method discoverability issue</PackageReleaseNotes>
+    <Version>3.1.0</Version>
+    <PackageReleaseNotes>Include assertion context for better error messages</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 

--- a/src/Functional.Primitives.FluentAssertions/OptionTypeAssertions.cs
+++ b/src/Functional.Primitives.FluentAssertions/OptionTypeAssertions.cs
@@ -15,6 +15,8 @@ namespace Functional.Primitives.FluentAssertions
 	[DebuggerNonUserCode]
 	public partial class OptionTypeAssertions<T>
 	{
+		private const string IDENTIFIER = "option";
+
 		private readonly Option<T> _subject;
 
 		/// <summary>
@@ -33,11 +35,13 @@ namespace Functional.Primitives.FluentAssertions
 		/// <param name="because">Additional information for if the assertion fails.</param>
 		/// <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because"/>.</param>
 		/// <returns></returns>
+		[CustomAssertion]
 		public AndConstraint<ObjectAssertions> Be(Option<T> expected, string because = "", params object[] becauseArgs)
 		{
 			Execute.Assertion
 				.ForCondition(_subject.Equals(expected))
 				.BecauseOf(because, becauseArgs)
+				.WithDefaultIdentifier(IDENTIFIER)
 				.FailWith(MakeFailReason);
 
 			return new AndConstraint<ObjectAssertions>(new ObjectAssertions(_subject));
@@ -45,7 +49,7 @@ namespace Functional.Primitives.FluentAssertions
 			FailReason MakeFailReason()
 			{
 				var builder = new StringBuilder();
-				builder.AppendLine($"Expected to be equal{{reason}}, but the two Option<{typeof(T)}> are not equal.");
+				builder.AppendLine($"Expected {{context:{IDENTIFIER}}} to be equal to the expected value{{reason}}, but the two Option<{typeof(T)}> are not equal.");
 				builder.AppendLine("Subject: " + _subject);
 				builder.AppendLine("Expected: " + expected);
 
@@ -58,12 +62,14 @@ namespace Functional.Primitives.FluentAssertions
 		/// </summary>
 		/// <param name="because">Additional information for if the assertion fails.</param>
 		/// <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because"/>.</param>
+		[CustomAssertion]
 		public AndOptionValueConstraint<T> HaveValue(string because = "", params object[] becauseArgs)
 		{
 			Execute.Assertion
 				.ForCondition(_subject.HasValue())
 				.BecauseOf(because, becauseArgs)
-				.FailWith("Expected to have value{reason}, but received no value instead.");
+				.WithDefaultIdentifier(IDENTIFIER)
+				.FailWith($"Expected {{context:{IDENTIFIER}}} to have value{{reason}}, but received no value instead.", _subject);
 
 			return new AndOptionValueConstraint<T>(_subject.ValueUnsafe());
 		}
@@ -73,17 +79,19 @@ namespace Functional.Primitives.FluentAssertions
 		/// </summary>
 		/// <param name="because">Additional information for if the assertion fails.</param>
 		/// <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because"/>.</param>
+		[CustomAssertion]
 		public void NotHaveValue(string because = "", params object[] becauseArgs)
 		{
 			Execute.Assertion
 				.ForCondition(!_subject.HasValue())
 				.BecauseOf(because, becauseArgs)
+				.WithDefaultIdentifier(IDENTIFIER)
 				.FailWith(FailReasonForNotHaveValue);
 
 			FailReason FailReasonForNotHaveValue()
 			{
 				var builder = new StringBuilder();
-				builder.AppendLine("Expected to not have value{reason}, but received a value instead:");
+				builder.AppendLine($"Expected {{context:{IDENTIFIER}}} to not have value{{reason}}, but received a value instead:");
 				builder.AppendLine(_subject.ValueUnsafe().ToString());
 
 				return new FailReason(builder.ToString());

--- a/src/Functional.Primitives.FluentAssertions/OptionTypeAssertions.cs
+++ b/src/Functional.Primitives.FluentAssertions/OptionTypeAssertions.cs
@@ -13,7 +13,7 @@ namespace Functional.Primitives.FluentAssertions
 	/// </summary>
 	/// <typeparam name="T">The contained type.</typeparam>
 	[DebuggerNonUserCode]
-	public partial class OptionTypeAssertions<T>
+	public class OptionTypeAssertions<T>
 	{
 		private const string IDENTIFIER = "option";
 
@@ -49,7 +49,7 @@ namespace Functional.Primitives.FluentAssertions
 			FailReason MakeFailReason()
 			{
 				var builder = new StringBuilder();
-				builder.AppendLine($"Expected {{context:{IDENTIFIER}}} to be equal to the expected value{{reason}}, but the two Option<{typeof(T)}> are not equal.");
+				builder.AppendLine($"Expected {{context:{IDENTIFIER}}} to be equal to the expected option{{reason}}, but the two Option<{typeof(T)}> are not equal.");
 				builder.AppendLine("Subject: " + _subject);
 				builder.AppendLine("Expected: " + expected);
 

--- a/src/Functional.Primitives.FluentAssertions/ResultTypeAssertions.cs
+++ b/src/Functional.Primitives.FluentAssertions/ResultTypeAssertions.cs
@@ -15,8 +15,10 @@ namespace Functional.Primitives.FluentAssertions
 	/// <typeparam name="TSuccess">The success value type.</typeparam>
 	/// <typeparam name="TFailure">The failure value type.</typeparam>
 	[DebuggerNonUserCode]
-	public partial class ResultTypeAssertions<TSuccess, TFailure>
+	public class ResultTypeAssertions<TSuccess, TFailure>
 	{
+		private const string IDENTIFIER = "result";
+
 		private readonly Result<TSuccess, TFailure> _subject;
 
 		/// <summary>
@@ -35,11 +37,13 @@ namespace Functional.Primitives.FluentAssertions
 		/// <param name="because">Additional information for if the assertion fails.</param>
 		/// <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because"/>.</param>
 		/// <returns></returns>
+		[CustomAssertion]
 		public AndConstraint<ObjectAssertions> Be(Result<TSuccess, TFailure> expected, string because = "", params object[] becauseArgs)
 		{
 			Execute.Assertion
 				.ForCondition(_subject.Equals(expected))
 				.BecauseOf(because, becauseArgs)
+				.WithDefaultIdentifier(IDENTIFIER)
 				.FailWith(MakeFailReason);
 
 			return new AndConstraint<ObjectAssertions>(new ObjectAssertions(_subject));
@@ -47,7 +51,7 @@ namespace Functional.Primitives.FluentAssertions
 			FailReason MakeFailReason()
 			{
 				var builder = new StringBuilder();
-				builder.AppendLine($"Expected to be equal{{reason}}, but the two Result<{typeof(TSuccess)}, {typeof(TFailure)}> are not equal.");
+				builder.AppendLine($"Expected {{context:{IDENTIFIER}}} to be equal to the expected result{{reason}}, but the two Result<{typeof(TSuccess)}, {typeof(TFailure)}> are not equal.");
 				builder.AppendLine("Subject: " + _subject);
 				builder.AppendLine("Expected: " + expected);
 
@@ -60,11 +64,13 @@ namespace Functional.Primitives.FluentAssertions
 		/// </summary>
 		/// <param name="because">Additional information for if the assertion fails.</param>
 		/// <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because"/>.</param>
+		[CustomAssertion]
 		public AndResultSuccessConstraint<TSuccess> BeSuccessful(string because = "", params object[] becauseArgs)
 		{
 			Execute.Assertion
 				.BecauseOf(because, becauseArgs)
 				.ForCondition(_subject.IsSuccess())
+				.WithDefaultIdentifier(IDENTIFIER)
 				.FailWith(FailReasonForBeSuccessful);
 
 			return new AndResultSuccessConstraint<TSuccess>(_subject.SuccessUnsafe());
@@ -72,7 +78,7 @@ namespace Functional.Primitives.FluentAssertions
 			FailReason FailReasonForBeSuccessful()
 			{
 				var builder = new StringBuilder();
-				builder.AppendLine("Expected result to be successful{reason}, but received faulted result instead:");
+				builder.AppendLine($"Expected {{context:{IDENTIFIER}}} to be successful{{reason}}, but received faulted result instead:");
 				builder.AppendLine(_subject.FailureUnsafe().ToString());
 
 				return new FailReason(builder.ToString());
@@ -84,11 +90,13 @@ namespace Functional.Primitives.FluentAssertions
 		/// </summary>
 		/// <param name="because">Additional information for if the assertion fails.</param>
 		/// <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because"/>.</param>
+		[CustomAssertion]
 		public AndResultFailureConstraint<TFailure> BeFaulted(string because = "", params object[] becauseArgs)
 		{
 			Execute.Assertion
 				.BecauseOf(because, becauseArgs)
 				.ForCondition(!_subject.IsSuccess())
+				.WithDefaultIdentifier(IDENTIFIER)
 				.FailWith(FailReasonForBeFaulted);
 
 			return new AndResultFailureConstraint<TFailure>(_subject.FailureUnsafe());
@@ -96,7 +104,7 @@ namespace Functional.Primitives.FluentAssertions
 			FailReason FailReasonForBeFaulted()
 			{
 				var builder = new StringBuilder();
-				builder.AppendLine("Expected result to be faulted{reason}, but received successful result instead:");
+				builder.AppendLine($"Expected {{context:{IDENTIFIER}}} to be faulted{{reason}}, but received successful result instead:");
 				builder.AppendLine(_subject.SuccessUnsafe().ToString());
 
 				return new FailReason(builder.ToString());


### PR DESCRIPTION
Includes context information (variable name or class member name) for better error messages when performing assertions on `Option<T>` and `Result<TSuccess, TFailure>` values.  Similar work can be performed for the `Union<...>` project as a separate PR if desired.