### PR TITLE
Update to FluentAssertions 6.0.0; add method overloads accepting Func<T, string> for better error messages

### DIFF
--- a/src/Functional.Primitives.FluentAssertions.Tests/OptionTypeAssertionsExtensionsTests.cs
+++ b/src/Functional.Primitives.FluentAssertions.Tests/OptionTypeAssertionsExtensionsTests.cs
@@ -16,7 +16,7 @@ namespace Functional.Primitives.FluentAssertions.Tests
 				Task.FromResult(Option.Some(VALUE))
 					.Should()
 					.HaveValue())
-			.Should().NotThrow();
+					.Should().NotThrowAsync();
 
 			[Fact]
 			public void ShouldNotThrowExceptionWhenAdditionalAssertionSucceeds() => new Func<Task>(() =>
@@ -24,14 +24,14 @@ namespace Functional.Primitives.FluentAssertions.Tests
 					.Should()
 					.HaveValue()
 					.AndValue(value => value.Should().Be(VALUE)))
-			.Should().NotThrow();
+					.Should().NotThrowAsync();
 
 			[Fact]
 			public void ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Option.None<int>())
 					.Should()
 					.HaveValue())
-			.Should().Throw<Exception>();
+					.Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void ShouldThrowExceptionWhenAdditionalAssertionFails() => new Func<Task>(() =>
@@ -39,16 +39,16 @@ namespace Functional.Primitives.FluentAssertions.Tests
 					.Should()
 					.HaveValue()
 					.AndValue(value => value.Should().Be(VALUE)))
-			.Should().NotThrow();
+					.Should().NotThrowAsync();
 		}
 
 		public class NoValueChecks
 		{
 			[Fact]
-			public void ShouldNotThrowException() => new Func<Task>(() => Task.FromResult(Option.None<int>()).Should().NotHaveValue()).Should().NotThrow();
+			public void ShouldNotThrowException() => new Func<Task>(() => Task.FromResult(Option.None<int>()).Should().NotHaveValue()).Should().NotThrowAsync();
 
 			[Fact]
-			public void ShouldThrowException() => new Func<Task>(() => Task.FromResult(Option.Some(3)).Should().NotHaveValue()).Should().Throw<Exception>();
+			public void ShouldThrowException() => new Func<Task>(() => Task.FromResult(Option.Some(3)).Should().NotHaveValue()).Should().ThrowAsync<Exception>();
 		}
 
 		public class IntegerOptionChecks
@@ -60,35 +60,35 @@ namespace Functional.Primitives.FluentAssertions.Tests
 				Task.FromResult(Option.Some(VALUE))
 					.Should()
 					.Be(Option.Some(VALUE)))
-			.Should().NotThrow();
+					.Should().NotThrowAsync();
 
 			[Fact]
 			public void ShouldNotThrowExceptionWhenBothNone() => new Func<Task>(() =>
 				Task.FromResult(Option.None<int>())
 					.Should()
 					.Be(Option.None<int>()))
-			.Should().NotThrow();
+					.Should().NotThrowAsync();
 
 			[Fact]
 			public void ShouldThrowExceptionWhenBothSomeButDifferentValues() => new Func<Task>(() =>
 				Task.FromResult(Option.Some(VALUE))
 					.Should()
 					.Be(Option.Some(VALUE+1)))
-			.Should().Throw<Exception>();
+					.Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void ShouldThrowExceptionWhenLeftIsSomeButRightIsNone() => new Func<Task>(() =>
 				Task.FromResult(Option.Some(VALUE))
 					.Should()
 					.Be(Option.None<int>()))
-			.Should().Throw<Exception>();
+					.Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void ShouldThrowExceptionWhenLeftIsNoneButRightIsSome() => new Func<Task>(() =>
 				Task.FromResult(Option.None<int>())
 					.Should()
 					.Be(Option.Some(VALUE)))
-			.Should().Throw<Exception>();
+					.Should().ThrowAsync<Exception>();
 		}
 
 		public class StringOptionChecks
@@ -100,35 +100,35 @@ namespace Functional.Primitives.FluentAssertions.Tests
 				Task.FromResult(Option.Some(VALUE))
 					.Should()
 					.Be(Option.Some(VALUE)))
-			.Should().NotThrow();
+					.Should().NotThrowAsync();
 
 			[Fact]
 			public void ShouldNotThrowExceptionWhenBothNone() => new Func<Task>(() =>
 				Task.FromResult(Option.None<string>())
 					.Should()
 					.Be(Option.None<string>()))
-			.Should().NotThrow();
+					.Should().NotThrowAsync();
 
 			[Fact]
 			public void ShouldThrowExceptionWhenBothSomeButDifferentValues() => new Func<Task>(() =>
 				Task.FromResult(Option.Some(VALUE))
 					.Should()
 					.Be(Option.Some(VALUE + 1)))
-			.Should().Throw<Exception>();
+					.Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void ShouldThrowExceptionWhenLeftIsSomeButRightIsNone() => new Func<Task>(() =>
 				Task.FromResult(Option.Some(VALUE))
 					.Should()
 					.Be(Option.None<string>()))
-			.Should().Throw<Exception>();
+					.Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void ShouldThrowExceptionWhenLeftIsNoneButRightIsSome() => new Func<Task>(() =>
 				Task.FromResult(Option.None<string>())
 					.Should()
 					.Be(Option.Some(VALUE)))
-			.Should().Throw<Exception>();
+					.Should().ThrowAsync<Exception>();
 		}
 
 		public class EquatableClassOptionChecks
@@ -140,35 +140,35 @@ namespace Functional.Primitives.FluentAssertions.Tests
 				Task.FromResult(Option.Some(new EquatableClass(VALUE)))
 					.Should()
 					.Be(Option.Some(new EquatableClass(VALUE))))
-			.Should().NotThrow();
+					.Should().NotThrowAsync();
 
 			[Fact]
 			public void ShouldNotThrowExceptionWhenBothNone() => new Func<Task>(() =>
 				Task.FromResult(Option.None<string>())
 					.Should()
 					.Be(Option.None<string>()))
-			.Should().NotThrow();
+					.Should().NotThrowAsync();
 
 			[Fact]
 			public void ShouldThrowExceptionWhenBothSomeButDifferentValues() => new Func<Task>(() =>
 				Task.FromResult(Option.Some(new EquatableClass(VALUE)))
 					.Should()
 					.Be(Option.Some(new EquatableClass(VALUE + 1))))
-			.Should().Throw<Exception>();
+					.Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void ShouldThrowExceptionWhenLeftIsSomeButRightIsNone() => new Func<Task>(() =>
 				Task.FromResult(Option.Some(new EquatableClass(VALUE)))
 					.Should()
 					.Be(Option.None<EquatableClass>()))
-			.Should().Throw<Exception>();
+					.Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void ShouldThrowExceptionWhenLeftIsNoneButRightIsSome() => new Func<Task>(() =>
 				Task.FromResult(Option.None<EquatableClass>())
 					.Should()
 					.Be(Option.Some(new EquatableClass(VALUE))))
-			.Should().Throw<Exception>();
+					.Should().ThrowAsync<Exception>();
 
 			#region Models
 

--- a/src/Functional.Primitives.FluentAssertions.Tests/OptionTypeAssertionsTests.cs
+++ b/src/Functional.Primitives.FluentAssertions.Tests/OptionTypeAssertionsTests.cs
@@ -76,6 +76,35 @@ namespace Functional.Primitives.FluentAssertions.Tests
 					.Throw<Exception>()
 					.And.Message.Should().ContainAll(nameof(envelope), nameof(OptionEnvelope<int>.Data));
 			}
+
+			[Fact]
+			public void ShouldThrowExceptionWithCustomOutput()
+			{
+				const int ID = 1337;
+				const string NAME = "TEST";
+
+				var result = Option.Some(new DummyModel(ID, NAME));
+				new Action(() => result.Should().NotHaveValue(m => $"[{m.ID}] {m.Name}"))
+					.Should()
+					.Throw<Exception>()
+					.And.Message.Should().ContainAll($"[{ID}]", NAME);
+			}
+
+			#region Models
+
+			private class DummyModel
+			{
+				public DummyModel(int id, string name)
+				{
+					ID = id;
+					Name = name;
+				}
+
+				public int ID { get; }
+				public string Name { get; }
+			}
+
+			#endregion
 		}
 
 		public class IntegerOptionChecks

--- a/src/Functional.Primitives.FluentAssertions.Tests/ResultTypeAssertionsExtensionsTests.cs
+++ b/src/Functional.Primitives.FluentAssertions.Tests/ResultTypeAssertionsExtensionsTests.cs
@@ -12,22 +12,22 @@ namespace Functional.Primitives.FluentAssertions.Tests
 			private const int VALUE = 3;
 
 			[Fact]
-			public void ShouldNotThrowException() => new Func<Task>(() =>
+			public void ShouldNotThrowAsyncException() => new Func<Task>(() =>
 				Task.FromResult(Result.Success<int, Exception>(VALUE))
 					.Should()
 					.BeSuccessful("an exception occurred"))
-			.Should().NotThrow();
+					.Should().NotThrowAsync();
 
 			[Fact]
-			public void ShouldNotThrowExceptionWhenAdditionalAssertionSucceeds() => new Func<Task>(() =>
+			public void ShouldNotThrowAsyncExceptionWhenAdditionalAssertionSucceeds() => new Func<Task>(() =>
 				Task.FromResult(Result.Success<int, Exception>(VALUE))
 					.Should()
 					.BeSuccessful()
 					.AndSuccessValue(value => value.Should().Be(VALUE)))
-			.Should().NotThrow();
+					.Should().NotThrowAsync();
 
 			[Fact]
-			public void ShouldThrowException() => new Func<Task>(() => Task.FromResult(Result.Failure<int, Exception>(new Exception())).Should().BeSuccessful()).Should().Throw<Exception>();
+			public void ShouldThrowException() => new Func<Task>(() => Task.FromResult(Result.Failure<int, Exception>(new Exception())).Should().BeSuccessful()).Should().ThrowAsync<Exception>();
 		}
 
 		public class FailureChecks
@@ -35,71 +35,71 @@ namespace Functional.Primitives.FluentAssertions.Tests
 			private const string VALUE = "value";
 
 			[Fact]
-			public void ShouldNotThrowException() => new Func<Task>(() =>
+			public void ShouldNotThrowAsyncException() => new Func<Task>(() =>
 				Task.FromResult(Result.Failure<int, Exception>(new Exception(VALUE)))
 					.Should()
 					.BeFaulted())
-			.Should().NotThrow();
+					.Should().NotThrowAsync();
 
 			[Fact]
-			public void ShouldNotThrowExceptionWhenAdditionalAssertionSucceeds() => new Func<Task>(() =>
+			public void ShouldNotThrowAsyncExceptionWhenAdditionalAssertionSucceeds() => new Func<Task>(() =>
 				Task.FromResult(Result.Failure<int, Exception>(new Exception(VALUE)))
 					.Should()
 					.BeFaulted()
 					.AndFailureValue(failure => failure.Should().Match<Exception>(ex => ex.Message == VALUE)))
-			.Should().NotThrow();
+					.Should().NotThrowAsync();
 
 			[Fact]
 			public void ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Result.Success<int, Exception>(3))
 					.Should()
 					.BeFaulted())
-			.Should().Throw<Exception>();
+					.Should().ThrowAsync<Exception>();
 		}
 
 		public class EqualityChecks
 		{
 			[Fact]
-			public void ShouldNotThrowExceptionWhenBothSuccessAndBothHaveSameSuccessValues() => new Func<Task>(() =>
+			public void ShouldNotThrowAsyncExceptionWhenBothSuccessAndBothHaveSameSuccessValues() => new Func<Task>(() =>
 				Task.FromResult(Result.Success<int, string>(1337))
 					.Should()
 					.Be(Result.Success<int, string>(1337)))
-			.Should().NotThrow();
+					.Should().NotThrowAsync();
 
 			[Fact]
-			public void ShouldNotThrowExceptionWhenBothFaultedAndBothHaveSameFailureValues() => new Func<Task>(() =>
+			public void ShouldNotThrowAsyncExceptionWhenBothFaultedAndBothHaveSameFailureValues() => new Func<Task>(() =>
 				Task.FromResult(Result.Failure<int, string>("error"))
 					.Should()
 					.Be(Result.Failure<int, string>("error")))
-			.Should().NotThrow();
+					.Should().NotThrowAsync();
 
 			[Fact]
 			public void ShouldThrowExceptionWhenBothSuccessButHaveDifferentSuccessValues() => new Func<Task>(() =>
 				Task.FromResult(Result.Success<int, string>(3))
 					.Should()
 					.Be(Result.Success<int, string>(4)))
-			.Should().Throw<Exception>();
+					.Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void ShouldThrowExceptionWhenBothFaultedButHaveDifferentFailureValues() => new Func<Task>(() =>
 				Task.FromResult(Result.Failure<int, string>("1"))
 					.Should()
 					.Be(Result.Failure<int, string>("2")))
-			.Should().Throw<Exception>();
+					.Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void ShouldThrowExceptionWhenLeftIsSuccessAndRightIsFaulted() => new Func<Task>(() =>
 				Task.FromResult(Result.Success<int, string>(3))
 					.Should()
 					.Be(Result.Failure<int, string>("e")))
-			.Should().Throw<Exception>();
+					.Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void ShouldThrowExceptionWhenLeftIsFaultedAndRightIsSuccess() => new Func<Task>(() =>
 				Task.FromResult(Result.Failure<int, string>("e"))
 					.Should()
 					.Be(Result.Success<int, string>(3)))
-			.Should().Throw<Exception>();
+					.Should().ThrowAsync<Exception>();
 		}
 	}
 }

--- a/src/Functional.Primitives.FluentAssertions.Tests/ResultTypeAssertionsTests.cs
+++ b/src/Functional.Primitives.FluentAssertions.Tests/ResultTypeAssertionsTests.cs
@@ -50,6 +50,19 @@ namespace Functional.Primitives.FluentAssertions.Tests
 					.Throw<Exception>()
 					.And.Message.Should().ContainAll(nameof(envelope), nameof(ResultEnvelope<int, Exception>.Data));
 			}
+
+			[Fact]
+			public void ShouldThrowExceptionWithCustomOutput()
+			{
+				const int ID = 1337;
+				const string NAME = "TEST";
+
+				var result = Result.Failure<int, DummyModel>(new DummyModel(ID, NAME));
+				new Action(() => result.Should().BeSuccessful(m => $"[{m.ID}] {m.Name}"))
+					.Should()
+					.Throw<Exception>()
+					.And.Message.Should().ContainAll($"[{ID}]", NAME);
+			}
 		}
 
 		public class FailureChecks
@@ -94,7 +107,20 @@ namespace Functional.Primitives.FluentAssertions.Tests
 				new Action(() => envelope.Data.Should().BeFaulted())
 					.Should()
 					.Throw<Exception>()
-					.And.Message.Should().Contain(nameof(envelope), nameof(ResultEnvelope<int, Exception>.Data));
+					.And.Message.Should().ContainAll(nameof(envelope), nameof(ResultEnvelope<int, Exception>.Data));
+			}
+
+			[Fact]
+			public void ShouldThrowExceptionWithCustomOutput()
+			{
+				const int ID = 1337;
+				const string NAME = "TEST";
+
+				var result = Result.Success<DummyModel, string>(new DummyModel(ID, NAME));
+				new Action(() => result.Should().BeFaulted(m => $"[{m.ID}] {m.Name}"))
+					.Should()
+					.Throw<Exception>()
+					.And.Message.Should().ContainAll($"[{ID}]", NAME);
 			}
 		}
 
@@ -197,6 +223,20 @@ namespace Functional.Primitives.FluentAssertions.Tests
 			}
 		}
 
+		#region Models
+
+		private class DummyModel
+		{
+			public DummyModel(int id, string name)
+			{
+				ID = id;
+				Name = name;
+			}
+
+			public int ID { get; }
+			public string Name { get; }
+		}
+
 		private class ResultEnvelope<TSuccess, TFailure>
 		{
 			public ResultEnvelope(Result<TSuccess, TFailure> data)
@@ -206,5 +246,7 @@ namespace Functional.Primitives.FluentAssertions.Tests
 
 			public Result<TSuccess, TFailure> Data { get; }
 		}
+
+		#endregion
 	}
 }

--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.csproj
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.csproj
@@ -11,7 +11,7 @@
     <RepositoryType></RepositoryType>
     <PackageTags>functional, MSTest, MSTest2, NUnit, xUnit2, xUnit, TDD, Fluent, netcore, netstandard</PackageTags>
     <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.Utilities</PackageProjectUrl>
-    <Version>3.1.0</Version>
+    <Version>4.0.0</Version>
     <PackageReleaseNotes>Include assertion context for better error messages</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="[5.*,6.0)" />
+    <PackageReference Include="FluentAssertions" Version="[6.*,7.0)" />
     <PackageReference Include="Functional.Primitives" Version="[2.*,3.0)" />
     <PackageReference Include="Functional.Primitives.Extensions" Version="[2.*,3.0)" />
   </ItemGroup>

--- a/src/Functional.Primitives.FluentAssertions/OptionTypeAssertions.cs
+++ b/src/Functional.Primitives.FluentAssertions/OptionTypeAssertions.cs
@@ -81,7 +81,19 @@ namespace Functional.Primitives.FluentAssertions
 		/// <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because"/>.</param>
 		[CustomAssertion]
 		public void NotHaveValue(string because = "", params object[] becauseArgs)
+			=> NotHaveValue(x => x.ToString(), because, becauseArgs);
+
+		/// <summary>
+		/// Verifies that the subject <see cref="Option{T}"/> does not hold a value.
+		/// </summary>
+		/// <param name="outputFunc">Function that maps <typeparamref name="T"/> to a string that will be included in the error message when the assertion fails.</param>
+		/// <param name="because">Additional information for if the assertion fails.</param>
+		/// <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because"/>.</param>
+		[CustomAssertion]
+		public void NotHaveValue(Func<T, string> outputFunc, string because = "", params object[] becauseArgs)
 		{
+			if (outputFunc == null) throw new ArgumentNullException(nameof(outputFunc));
+
 			Execute.Assertion
 				.ForCondition(!_subject.HasValue())
 				.BecauseOf(because, becauseArgs)
@@ -92,7 +104,7 @@ namespace Functional.Primitives.FluentAssertions
 			{
 				var builder = new StringBuilder();
 				builder.AppendLine($"Expected {{context:{IDENTIFIER}}} to not have value{{reason}}, but received a value instead:");
-				builder.AppendLine(_subject.ValueUnsafe().ToString());
+				builder.AppendLine(outputFunc.Invoke(_subject.ValueUnsafe()));
 
 				return new FailReason(builder.ToString());
 			}

--- a/src/Functional.Primitives.FluentAssertions/ResultTypeAssertions.cs
+++ b/src/Functional.Primitives.FluentAssertions/ResultTypeAssertions.cs
@@ -78,6 +78,8 @@ namespace Functional.Primitives.FluentAssertions
 		[CustomAssertion]
 		public AndResultSuccessConstraint<TSuccess> BeSuccessful(Func<TFailure, string> outputFunc, string because = "", params object[] becauseArgs)
 		{
+			if (outputFunc == null) throw new ArgumentNullException(nameof(outputFunc));
+
 			Execute.Assertion
 				.BecauseOf(because, becauseArgs)
 				.ForCondition(_subject.IsSuccess())

--- a/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskAdHocWithEightTypes.cs
+++ b/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskAdHocWithEightTypes.cs
@@ -12,132 +12,132 @@ namespace Functional.Unions.FluentAssertions.Tests
 			[Fact]
 			public void When_EqualityIsTrue_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(ModelEight)).Value().Should().Be(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(ModelEight).Value())
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_EqualityIsFalse_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(ModelEight)).Value().Should().Be(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(new ClassEight()).Value())
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsOne_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(ModelOne)).Value().Should().BeOfTypeOne()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsNotOne_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(ModelOne)).Value().Should().BeOfTypeTwo()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsTwo_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(ModelTwo)).Value().Should().BeOfTypeTwo()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsNotTwo_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(ModelTwo)).Value().Should().BeOfTypeOne()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsThreeAndExpectedTypeIsThree_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(ModelThree)).Value().Should().BeOfTypeThree()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsThreeAndExpectedTypeIsNotThree_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(ModelThree)).Value().Should().BeOfTypeTwo()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsFourAndExpectedTypeIsFour_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(ModelFour)).Value().Should().BeOfTypeFour()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFourAndExpectedTypeIsNotFour_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(ModelFour)).Value().Should().BeOfTypeThree()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsFiveAndExpectedTypeIsFive_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(ModelFive)).Value().Should().BeOfTypeFive()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFiveAndExpectedTypeIsNotFive_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(ModelFive)).Value().Should().BeOfTypeFour()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsSixAndExpectedTypeIsSix_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(ModelSix)).Value().Should().BeOfTypeSix()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsSixAndExpectedTypeIsNotSix_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(ModelSix)).Value().Should().BeOfTypeFive()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsSevenAndExpectedTypeIsSeven_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(ModelSeven)).Value().Should().BeOfTypeSeven()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsSevenAndExpectedTypeIsNotSeven_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(ModelSeven)).Value().Should().BeOfTypeSix()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsEightAndExpectedTypeIsEight_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(ModelEight)).Value().Should().BeOfTypeEight()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsEightAndExpectedTypeIsNotEight_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(ModelEight)).Value().Should().BeOfTypeSeven()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(ModelOne)).Value().Should().BeOfTypeOne().AndValue(value => value.Should().Be(ModelOne))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(ModelTwo)).Value().Should().BeOfTypeTwo().AndValue(value => value.Should().Be(ModelTwo))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsThreeAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(ModelThree)).Value().Should().BeOfTypeThree().AndValue(value => value.Should().Be(ModelThree))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFourAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(ModelFour)).Value().Should().BeOfTypeFour().AndValue(value => value.Should().Be(ModelFour))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFiveAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(ModelFive)).Value().Should().BeOfTypeFive().AndValue(value => value.Should().Be(ModelFive))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsSixAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(ModelSix)).Value().Should().BeOfTypeSix().AndValue(value => value.Should().Be(ModelSix))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsSevenAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(ModelSeven)).Value().Should().BeOfTypeSeven().AndValue(value => value.Should().Be(ModelSeven))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsEightAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven, ClassEight>().Create(ModelEight)).Value().Should().BeOfTypeEight().AndValue(value => value.Should().Be(ModelEight))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 		}
 	}
 }

--- a/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskAdHocWithFiveTypes.cs
+++ b/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskAdHocWithFiveTypes.cs
@@ -12,87 +12,87 @@ namespace Functional.Unions.FluentAssertions.Tests
 			[Fact]
 			public void When_EqualityIsTrue_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive>().Create(ModelFive)).Value().Should().Be(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive>().Create(ModelFive).Value())
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_EqualityIsFalse_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive>().Create(ModelFive)).Value().Should().Be(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive>().Create(new ClassFive()).Value())
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsOne_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive>().Create(ModelOne)).Value().Should().BeOfTypeOne()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsNotOne_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive>().Create(ModelOne)).Value().Should().BeOfTypeTwo()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsTwo_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive>().Create(ModelTwo)).Value().Should().BeOfTypeTwo()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsNotTwo_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive>().Create(ModelTwo)).Value().Should().BeOfTypeOne()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsThreeAndExpectedTypeIsThree_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive>().Create(ModelThree)).Value().Should().BeOfTypeThree()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsThreeAndExpectedTypeIsNotThree_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive>().Create(ModelThree)).Value().Should().BeOfTypeTwo()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsFourAndExpectedTypeIsFour_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive>().Create(ModelFour)).Value().Should().BeOfTypeFour()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFourAndExpectedTypeIsNotFour_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive>().Create(ModelFour)).Value().Should().BeOfTypeThree()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsFiveAndExpectedTypeIsFive_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive>().Create(ModelFive)).Value().Should().BeOfTypeFive()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFiveAndExpectedTypeIsNotFive_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive>().Create(ModelFive)).Value().Should().BeOfTypeFour()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive>().Create(ModelOne)).Value().Should().BeOfTypeOne().AndValue(value => value.Should().Be(ModelOne))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive>().Create(ModelTwo)).Value().Should().BeOfTypeTwo().AndValue(value => value.Should().Be(ModelTwo))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsThreeAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive>().Create(ModelThree)).Value().Should().BeOfTypeThree().AndValue(value => value.Should().Be(ModelThree))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFourAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive>().Create(ModelFour)).Value().Should().BeOfTypeFour().AndValue(value => value.Should().Be(ModelFour))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFiveAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive>().Create(ModelFive)).Value().Should().BeOfTypeFive().AndValue(value => value.Should().Be(ModelFive))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 		}
 	}
 }

--- a/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskAdHocWithFourTypes.cs
+++ b/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskAdHocWithFourTypes.cs
@@ -12,72 +12,72 @@ namespace Functional.Unions.FluentAssertions.Tests
 			[Fact]
 			public void When_EqualityIsTrue_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour>().Create(ModelFour)).Value().Should().Be(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour>().Create(ModelFour).Value())
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_EqualityIsFalse_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour>().Create(ModelFour)).Value().Should().Be(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour>().Create(new ClassFour()).Value())
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsOne_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour>().Create(ModelOne)).Value().Should().BeOfTypeOne()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsNotOne_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour>().Create(ModelOne)).Value().Should().BeOfTypeTwo()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsTwo_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour>().Create(ModelTwo)).Value().Should().BeOfTypeTwo()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsNotTwo_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour>().Create(ModelTwo)).Value().Should().BeOfTypeOne()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsThreeAndExpectedTypeIsThree_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour>().Create(ModelThree)).Value().Should().BeOfTypeThree()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsThreeAndExpectedTypeIsNotThree_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour>().Create(ModelThree)).Value().Should().BeOfTypeTwo()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsFourAndExpectedTypeIsFour_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour>().Create(ModelFour)).Value().Should().BeOfTypeFour()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFourAndExpectedTypeIsNotFour_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour>().Create(ModelFour)).Value().Should().BeOfTypeThree()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour>().Create(ModelOne)).Value().Should().BeOfTypeOne().AndValue(value => value.Should().Be(ModelOne))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour>().Create(ModelTwo)).Value().Should().BeOfTypeTwo().AndValue(value => value.Should().Be(ModelTwo))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsThreeAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour>().Create(ModelThree)).Value().Should().BeOfTypeThree().AndValue(value => value.Should().Be(ModelThree))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFourAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour>().Create(ModelFour)).Value().Should().BeOfTypeFour().AndValue(value => value.Should().Be(ModelFour))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 		}
 	}
 }

--- a/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskAdHocWithSevenTypes.cs
+++ b/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskAdHocWithSevenTypes.cs
@@ -12,117 +12,117 @@ namespace Functional.Unions.FluentAssertions.Tests
 			[Fact]
 			public void When_EqualityIsTrue_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven>().Create(ModelSeven)).Value().Should().Be(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven>().Create(ModelSeven).Value())
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_EqualityIsFalse_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven>().Create(ModelSeven)).Value().Should().Be(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven>().Create(new ClassSeven()).Value())
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsOne_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven>().Create(ModelOne)).Value().Should().BeOfTypeOne()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsNotOne_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven>().Create(ModelOne)).Value().Should().BeOfTypeTwo()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsTwo_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven>().Create(ModelTwo)).Value().Should().BeOfTypeTwo()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsNotTwo_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven>().Create(ModelTwo)).Value().Should().BeOfTypeOne()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsThreeAndExpectedTypeIsThree_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven>().Create(ModelThree)).Value().Should().BeOfTypeThree()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsThreeAndExpectedTypeIsNotThree_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven>().Create(ModelThree)).Value().Should().BeOfTypeTwo()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsFourAndExpectedTypeIsFour_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven>().Create(ModelFour)).Value().Should().BeOfTypeFour()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFourAndExpectedTypeIsNotFour_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven>().Create(ModelFour)).Value().Should().BeOfTypeThree()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsFiveAndExpectedTypeIsFive_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven>().Create(ModelFive)).Value().Should().BeOfTypeFive()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFiveAndExpectedTypeIsNotFive_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven>().Create(ModelFive)).Value().Should().BeOfTypeFour()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsSixAndExpectedTypeIsSix_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven>().Create(ModelSix)).Value().Should().BeOfTypeSix()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsSixAndExpectedTypeIsNotSix_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven>().Create(ModelSix)).Value().Should().BeOfTypeFive()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsSevenAndExpectedTypeIsSeven_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven>().Create(ModelSeven)).Value().Should().BeOfTypeSeven()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsSevenAndExpectedTypeIsNotSeven_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven>().Create(ModelSeven)).Value().Should().BeOfTypeSix()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven>().Create(ModelOne)).Value().Should().BeOfTypeOne().AndValue(value => value.Should().Be(ModelOne))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven>().Create(ModelTwo)).Value().Should().BeOfTypeTwo().AndValue(value => value.Should().Be(ModelTwo))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsThreeAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven>().Create(ModelThree)).Value().Should().BeOfTypeThree().AndValue(value => value.Should().Be(ModelThree))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFourAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven>().Create(ModelFour)).Value().Should().BeOfTypeFour().AndValue(value => value.Should().Be(ModelFour))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFiveAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven>().Create(ModelFive)).Value().Should().BeOfTypeFive().AndValue(value => value.Should().Be(ModelFive))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsSixAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven>().Create(ModelSix)).Value().Should().BeOfTypeSix().AndValue(value => value.Should().Be(ModelSix))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsSevenAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix, ClassSeven>().Create(ModelSeven)).Value().Should().BeOfTypeSeven().AndValue(value => value.Should().Be(ModelSeven))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 		}
 	}
 }

--- a/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskAdHocWithSixTypes.cs
+++ b/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskAdHocWithSixTypes.cs
@@ -12,102 +12,102 @@ namespace Functional.Unions.FluentAssertions.Tests
 			[Fact]
 			public void When_EqualityIsTrue_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix>().Create(ModelSix)).Value().Should().Be(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix>().Create(ModelSix).Value())
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_EqualityIsFalse_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix>().Create(ModelSix)).Value().Should().Be(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix>().Create(new ClassSix()).Value())
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsOne_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix>().Create(ModelOne)).Value().Should().BeOfTypeOne()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsNotOne_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix>().Create(ModelOne)).Value().Should().BeOfTypeTwo()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsTwo_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix>().Create(ModelTwo)).Value().Should().BeOfTypeTwo()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsNotTwo_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix>().Create(ModelTwo)).Value().Should().BeOfTypeOne()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsThreeAndExpectedTypeIsThree_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix>().Create(ModelThree)).Value().Should().BeOfTypeThree()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsThreeAndExpectedTypeIsNotThree_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix>().Create(ModelThree)).Value().Should().BeOfTypeTwo()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsFourAndExpectedTypeIsFour_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix>().Create(ModelFour)).Value().Should().BeOfTypeFour()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFourAndExpectedTypeIsNotFour_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix>().Create(ModelFour)).Value().Should().BeOfTypeThree()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsFiveAndExpectedTypeIsFive_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix>().Create(ModelFive)).Value().Should().BeOfTypeFive()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFiveAndExpectedTypeIsNotFive_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix>().Create(ModelFive)).Value().Should().BeOfTypeFour()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsSixAndExpectedTypeIsSix_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix>().Create(ModelSix)).Value().Should().BeOfTypeSix()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsSixAndExpectedTypeIsNotSix_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix>().Create(ModelSix)).Value().Should().BeOfTypeFive()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix>().Create(ModelOne)).Value().Should().BeOfTypeOne().AndValue(value => value.Should().Be(ModelOne))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix>().Create(ModelTwo)).Value().Should().BeOfTypeTwo().AndValue(value => value.Should().Be(ModelTwo))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsThreeAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix>().Create(ModelThree)).Value().Should().BeOfTypeThree().AndValue(value => value.Should().Be(ModelThree))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFourAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix>().Create(ModelFour)).Value().Should().BeOfTypeFour().AndValue(value => value.Should().Be(ModelFour))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFiveAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix>().Create(ModelFive)).Value().Should().BeOfTypeFive().AndValue(value => value.Should().Be(ModelFive))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsSixAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree, ClassFour, ClassFive, ClassSix>().Create(ModelSix)).Value().Should().BeOfTypeSix().AndValue(value => value.Should().Be(ModelSix))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 		}
 	}
 }

--- a/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskAdHocWithThreeTypes.cs
+++ b/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskAdHocWithThreeTypes.cs
@@ -12,57 +12,57 @@ namespace Functional.Unions.FluentAssertions.Tests
 			[Fact]
 			public void When_EqualityIsTrue_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree>().Create(ModelThree)).Value().Should().Be(Union.FromTypes<ClassOne, ClassTwo, ClassThree>().Create(ModelThree).Value())
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_EqualityIsFalse_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree>().Create(ModelThree)).Value().Should().Be(Union.FromTypes<ClassOne, ClassTwo, ClassThree>().Create(new ClassThree()).Value())
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsOne_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree>().Create(ModelOne)).Value().Should().BeOfTypeOne()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsNotOne_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree>().Create(ModelOne)).Value().Should().BeOfTypeTwo()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsTwo_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree>().Create(ModelTwo)).Value().Should().BeOfTypeTwo()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsNotTwo_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree>().Create(ModelTwo)).Value().Should().BeOfTypeOne()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsThreeAndExpectedTypeIsThree_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree>().Create(ModelThree)).Value().Should().BeOfTypeThree()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsThreeAndExpectedTypeIsNotThree_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree>().Create(ModelThree)).Value().Should().BeOfTypeTwo()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree>().Create(ModelOne)).Value().Should().BeOfTypeOne().AndValue(value => value.Should().Be(ModelOne))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree>().Create(ModelTwo)).Value().Should().BeOfTypeTwo().AndValue(value => value.Should().Be(ModelTwo))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsThreeAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo, ClassThree>().Create(ModelThree)).Value().Should().BeOfTypeThree().AndValue(value => value.Should().Be(ModelThree))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 		}
 	}
 }

--- a/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskAdHocWithTwoTypes.cs
+++ b/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskAdHocWithTwoTypes.cs
@@ -12,42 +12,42 @@ namespace Functional.Unions.FluentAssertions.Tests
 			[Fact]
 			public void When_EqualityIsTrue_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo>().Create(ModelTwo)).Value().Should().Be(Union.FromTypes<ClassOne, ClassTwo>().Create(ModelTwo).Value())
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_EqualityIsFalse_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo>().Create(ModelTwo)).Value().Should().Be(Union.FromTypes<ClassOne, ClassTwo>().Create(new ClassTwo()).Value())
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsOne_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo>().Create(ModelOne)).Value().Should().BeOfTypeOne()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsNotOne_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo>().Create(ModelOne)).Value().Should().BeOfTypeTwo()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsTwo_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo>().Create(ModelTwo)).Value().Should().BeOfTypeTwo()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsNotTwo_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo>().Create(ModelTwo)).Value().Should().BeOfTypeOne()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo>().Create(ModelOne)).Value().Should().BeOfTypeOne().AndValue(value => value.Should().Be(ModelOne))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromTypes<ClassOne, ClassTwo>().Create(ModelTwo)).Value().Should().BeOfTypeTwo().AndValue(value => value.Should().Be(ModelTwo))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 		}
 	}
 }

--- a/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskDefinitionWithEightTypes.cs
+++ b/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskDefinitionWithEightTypes.cs
@@ -12,132 +12,132 @@ namespace Functional.Unions.FluentAssertions.Tests
 			[Fact]
 			public void When_EqualityIsTrue_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<EightDefinition>().Create(ModelEight)).Value().Should().Be(Union.FromDefinition<EightDefinition>().Create(ModelEight).Value())
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_EqualityIsFalse_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<EightDefinition>().Create(ModelEight)).Value().Should().Be(Union.FromDefinition<EightDefinition>().Create(new ClassEight()).Value())
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsOne_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<EightDefinition>().Create(ModelOne)).Value().Should().BeOfTypeOne()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsNotOne_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<EightDefinition>().Create(ModelOne)).Value().Should().BeOfTypeTwo()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsTwo_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<EightDefinition>().Create(ModelTwo)).Value().Should().BeOfTypeTwo()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsNotTwo_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<EightDefinition>().Create(ModelTwo)).Value().Should().BeOfTypeOne()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsThreeAndExpectedTypeIsThree_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<EightDefinition>().Create(ModelThree)).Value().Should().BeOfTypeThree()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsThreeAndExpectedTypeIsNotThree_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<EightDefinition>().Create(ModelThree)).Value().Should().BeOfTypeTwo()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsFourAndExpectedTypeIsFour_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<EightDefinition>().Create(ModelFour)).Value().Should().BeOfTypeFour()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFourAndExpectedTypeIsNotFour_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<EightDefinition>().Create(ModelFour)).Value().Should().BeOfTypeThree()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsFiveAndExpectedTypeIsFive_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<EightDefinition>().Create(ModelFive)).Value().Should().BeOfTypeFive()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFiveAndExpectedTypeIsNotFive_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<EightDefinition>().Create(ModelFive)).Value().Should().BeOfTypeFour()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsSixAndExpectedTypeIsSix_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<EightDefinition>().Create(ModelSix)).Value().Should().BeOfTypeSix()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsSixAndExpectedTypeIsNotSix_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<EightDefinition>().Create(ModelSix)).Value().Should().BeOfTypeFive()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsSevenAndExpectedTypeIsSeven_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<EightDefinition>().Create(ModelSeven)).Value().Should().BeOfTypeSeven()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsSevenAndExpectedTypeIsNotSeven_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<EightDefinition>().Create(ModelSeven)).Value().Should().BeOfTypeSix()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsEightAndExpectedTypeIsEight_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<EightDefinition>().Create(ModelEight)).Value().Should().BeOfTypeEight()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsEightAndExpectedTypeIsNotEight_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<EightDefinition>().Create(ModelEight)).Value().Should().BeOfTypeSeven()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<EightDefinition>().Create(ModelOne)).Value().Should().BeOfTypeOne().AndValue(value => value.Should().Be(ModelOne))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<EightDefinition>().Create(ModelTwo)).Value().Should().BeOfTypeTwo().AndValue(value => value.Should().Be(ModelTwo))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsThreeAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<EightDefinition>().Create(ModelThree)).Value().Should().BeOfTypeThree().AndValue(value => value.Should().Be(ModelThree))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFourAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<EightDefinition>().Create(ModelFour)).Value().Should().BeOfTypeFour().AndValue(value => value.Should().Be(ModelFour))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFiveAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<EightDefinition>().Create(ModelFive)).Value().Should().BeOfTypeFive().AndValue(value => value.Should().Be(ModelFive))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsSixAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<EightDefinition>().Create(ModelSix)).Value().Should().BeOfTypeSix().AndValue(value => value.Should().Be(ModelSix))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsSevenAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<EightDefinition>().Create(ModelSeven)).Value().Should().BeOfTypeSeven().AndValue(value => value.Should().Be(ModelSeven))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsEightAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<EightDefinition>().Create(ModelEight)).Value().Should().BeOfTypeEight().AndValue(value => value.Should().Be(ModelEight))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 		}
 	}
 }

--- a/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskDefinitionWithFiveTypes.cs
+++ b/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskDefinitionWithFiveTypes.cs
@@ -12,87 +12,87 @@ namespace Functional.Unions.FluentAssertions.Tests
 			[Fact]
 			public void When_EqualityIsTrue_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FiveDefinition>().Create(ModelFive)).Value().Should().Be(Union.FromDefinition<FiveDefinition>().Create(ModelFive).Value())
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_EqualityIsFalse_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FiveDefinition>().Create(ModelFive)).Value().Should().Be(Union.FromDefinition<FiveDefinition>().Create(new ClassFive()).Value())
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsOne_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FiveDefinition>().Create(ModelOne)).Value().Should().BeOfTypeOne()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsNotOne_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FiveDefinition>().Create(ModelOne)).Value().Should().BeOfTypeTwo()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsTwo_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FiveDefinition>().Create(ModelTwo)).Value().Should().BeOfTypeTwo()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsNotTwo_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FiveDefinition>().Create(ModelTwo)).Value().Should().BeOfTypeOne()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsThreeAndExpectedTypeIsThree_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FiveDefinition>().Create(ModelThree)).Value().Should().BeOfTypeThree()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsThreeAndExpectedTypeIsNotThree_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FiveDefinition>().Create(ModelThree)).Value().Should().BeOfTypeTwo()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsFourAndExpectedTypeIsFour_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FiveDefinition>().Create(ModelFour)).Value().Should().BeOfTypeFour()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFourAndExpectedTypeIsNotFour_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FiveDefinition>().Create(ModelFour)).Value().Should().BeOfTypeThree()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsFiveAndExpectedTypeIsFive_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FiveDefinition>().Create(ModelFive)).Value().Should().BeOfTypeFive()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFiveAndExpectedTypeIsNotFive_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FiveDefinition>().Create(ModelFive)).Value().Should().BeOfTypeFour()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FiveDefinition>().Create(ModelOne)).Value().Should().BeOfTypeOne().AndValue(value => value.Should().Be(ModelOne))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FiveDefinition>().Create(ModelTwo)).Value().Should().BeOfTypeTwo().AndValue(value => value.Should().Be(ModelTwo))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsThreeAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FiveDefinition>().Create(ModelThree)).Value().Should().BeOfTypeThree().AndValue(value => value.Should().Be(ModelThree))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFourAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FiveDefinition>().Create(ModelFour)).Value().Should().BeOfTypeFour().AndValue(value => value.Should().Be(ModelFour))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFiveAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FiveDefinition>().Create(ModelFive)).Value().Should().BeOfTypeFive().AndValue(value => value.Should().Be(ModelFive))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 		}
 	}
 }

--- a/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskDefinitionWithFourTypes.cs
+++ b/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskDefinitionWithFourTypes.cs
@@ -12,72 +12,72 @@ namespace Functional.Unions.FluentAssertions.Tests
 			[Fact]
 			public void When_EqualityIsTrue_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FourDefinition>().Create(ModelFour)).Value().Should().Be(Union.FromDefinition<FourDefinition>().Create(ModelFour).Value())
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_EqualityIsFalse_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FourDefinition>().Create(ModelFour)).Value().Should().Be(Union.FromDefinition<FourDefinition>().Create(new ClassFour()).Value())
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsOne_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FourDefinition>().Create(ModelOne)).Value().Should().BeOfTypeOne()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsNotOne_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FourDefinition>().Create(ModelOne)).Value().Should().BeOfTypeTwo()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsTwo_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FourDefinition>().Create(ModelTwo)).Value().Should().BeOfTypeTwo()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsNotTwo_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FourDefinition>().Create(ModelTwo)).Value().Should().BeOfTypeOne()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsThreeAndExpectedTypeIsThree_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FourDefinition>().Create(ModelThree)).Value().Should().BeOfTypeThree()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsThreeAndExpectedTypeIsNotThree_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FourDefinition>().Create(ModelThree)).Value().Should().BeOfTypeTwo()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsFourAndExpectedTypeIsFour_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FourDefinition>().Create(ModelFour)).Value().Should().BeOfTypeFour()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFourAndExpectedTypeIsNotFour_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FourDefinition>().Create(ModelFour)).Value().Should().BeOfTypeThree()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FourDefinition>().Create(ModelOne)).Value().Should().BeOfTypeOne().AndValue(value => value.Should().Be(ModelOne))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FourDefinition>().Create(ModelTwo)).Value().Should().BeOfTypeTwo().AndValue(value => value.Should().Be(ModelTwo))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsThreeAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FourDefinition>().Create(ModelThree)).Value().Should().BeOfTypeThree().AndValue(value => value.Should().Be(ModelThree))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFourAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<FourDefinition>().Create(ModelFour)).Value().Should().BeOfTypeFour().AndValue(value => value.Should().Be(ModelFour))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 		}
 	}
 }

--- a/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskDefinitionWithSevenTypes.cs
+++ b/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskDefinitionWithSevenTypes.cs
@@ -12,117 +12,117 @@ namespace Functional.Unions.FluentAssertions.Tests
 			[Fact]
 			public void When_EqualityIsTrue_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SevenDefinition>().Create(ModelSeven)).Value().Should().Be(Union.FromDefinition<SevenDefinition>().Create(ModelSeven).Value())
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_EqualityIsFalse_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SevenDefinition>().Create(ModelSeven)).Value().Should().Be(Union.FromDefinition<SevenDefinition>().Create(new ClassSeven()).Value())
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsOne_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SevenDefinition>().Create(ModelOne)).Value().Should().BeOfTypeOne()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsNotOne_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SevenDefinition>().Create(ModelOne)).Value().Should().BeOfTypeTwo()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsTwo_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SevenDefinition>().Create(ModelTwo)).Value().Should().BeOfTypeTwo()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsNotTwo_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SevenDefinition>().Create(ModelTwo)).Value().Should().BeOfTypeOne()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsThreeAndExpectedTypeIsThree_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SevenDefinition>().Create(ModelThree)).Value().Should().BeOfTypeThree()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsThreeAndExpectedTypeIsNotThree_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SevenDefinition>().Create(ModelThree)).Value().Should().BeOfTypeTwo()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsFourAndExpectedTypeIsFour_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SevenDefinition>().Create(ModelFour)).Value().Should().BeOfTypeFour()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFourAndExpectedTypeIsNotFour_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SevenDefinition>().Create(ModelFour)).Value().Should().BeOfTypeThree()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsFiveAndExpectedTypeIsFive_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SevenDefinition>().Create(ModelFive)).Value().Should().BeOfTypeFive()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFiveAndExpectedTypeIsNotFive_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SevenDefinition>().Create(ModelFive)).Value().Should().BeOfTypeFour()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsSixAndExpectedTypeIsSix_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SevenDefinition>().Create(ModelSix)).Value().Should().BeOfTypeSix()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsSixAndExpectedTypeIsNotSix_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SevenDefinition>().Create(ModelSix)).Value().Should().BeOfTypeFive()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsSevenAndExpectedTypeIsSeven_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SevenDefinition>().Create(ModelSeven)).Value().Should().BeOfTypeSeven()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsSevenAndExpectedTypeIsNotSeven_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SevenDefinition>().Create(ModelSeven)).Value().Should().BeOfTypeSix()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SevenDefinition>().Create(ModelOne)).Value().Should().BeOfTypeOne().AndValue(value => value.Should().Be(ModelOne))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SevenDefinition>().Create(ModelTwo)).Value().Should().BeOfTypeTwo().AndValue(value => value.Should().Be(ModelTwo))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsThreeAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SevenDefinition>().Create(ModelThree)).Value().Should().BeOfTypeThree().AndValue(value => value.Should().Be(ModelThree))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFourAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SevenDefinition>().Create(ModelFour)).Value().Should().BeOfTypeFour().AndValue(value => value.Should().Be(ModelFour))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFiveAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SevenDefinition>().Create(ModelFive)).Value().Should().BeOfTypeFive().AndValue(value => value.Should().Be(ModelFive))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsSixAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SevenDefinition>().Create(ModelSix)).Value().Should().BeOfTypeSix().AndValue(value => value.Should().Be(ModelSix))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsSevenAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SevenDefinition>().Create(ModelSeven)).Value().Should().BeOfTypeSeven().AndValue(value => value.Should().Be(ModelSeven))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 		}
 	}
 }

--- a/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskDefinitionWithSixTypes.cs
+++ b/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskDefinitionWithSixTypes.cs
@@ -12,102 +12,102 @@ namespace Functional.Unions.FluentAssertions.Tests
 			[Fact]
 			public void When_EqualityIsTrue_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SixDefinition>().Create(ModelSix)).Value().Should().Be(Union.FromDefinition<SixDefinition>().Create(ModelSix).Value())
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_EqualityIsFalse_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SixDefinition>().Create(ModelSix)).Value().Should().Be(Union.FromDefinition<SixDefinition>().Create(new ClassSix()).Value())
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsOne_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SixDefinition>().Create(ModelOne)).Value().Should().BeOfTypeOne()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsNotOne_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SixDefinition>().Create(ModelOne)).Value().Should().BeOfTypeTwo()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsTwo_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SixDefinition>().Create(ModelTwo)).Value().Should().BeOfTypeTwo()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsNotTwo_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SixDefinition>().Create(ModelTwo)).Value().Should().BeOfTypeOne()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsThreeAndExpectedTypeIsThree_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SixDefinition>().Create(ModelThree)).Value().Should().BeOfTypeThree()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsThreeAndExpectedTypeIsNotThree_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SixDefinition>().Create(ModelThree)).Value().Should().BeOfTypeTwo()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsFourAndExpectedTypeIsFour_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SixDefinition>().Create(ModelFour)).Value().Should().BeOfTypeFour()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFourAndExpectedTypeIsNotFour_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SixDefinition>().Create(ModelFour)).Value().Should().BeOfTypeThree()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsFiveAndExpectedTypeIsFive_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SixDefinition>().Create(ModelFive)).Value().Should().BeOfTypeFive()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFiveAndExpectedTypeIsNotFive_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SixDefinition>().Create(ModelFive)).Value().Should().BeOfTypeFour()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsSixAndExpectedTypeIsSix_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SixDefinition>().Create(ModelSix)).Value().Should().BeOfTypeSix()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsSixAndExpectedTypeIsNotSix_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SixDefinition>().Create(ModelSix)).Value().Should().BeOfTypeFive()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SixDefinition>().Create(ModelOne)).Value().Should().BeOfTypeOne().AndValue(value => value.Should().Be(ModelOne))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SixDefinition>().Create(ModelTwo)).Value().Should().BeOfTypeTwo().AndValue(value => value.Should().Be(ModelTwo))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsThreeAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SixDefinition>().Create(ModelThree)).Value().Should().BeOfTypeThree().AndValue(value => value.Should().Be(ModelThree))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFourAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SixDefinition>().Create(ModelFour)).Value().Should().BeOfTypeFour().AndValue(value => value.Should().Be(ModelFour))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsFiveAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SixDefinition>().Create(ModelFive)).Value().Should().BeOfTypeFive().AndValue(value => value.Should().Be(ModelFive))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsSixAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<SixDefinition>().Create(ModelSix)).Value().Should().BeOfTypeSix().AndValue(value => value.Should().Be(ModelSix))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 		}
 	}
 }

--- a/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskDefinitionWithThreeTypes.cs
+++ b/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskDefinitionWithThreeTypes.cs
@@ -12,57 +12,57 @@ namespace Functional.Unions.FluentAssertions.Tests
 			[Fact]
 			public void When_EqualityIsTrue_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<ThreeDefinition>().Create(ModelThree)).Value().Should().Be(Union.FromDefinition<ThreeDefinition>().Create(ModelThree).Value())
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_EqualityIsFalse_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<ThreeDefinition>().Create(ModelThree)).Value().Should().Be(Union.FromDefinition<ThreeDefinition>().Create(new ClassThree()).Value())
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsOne_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<ThreeDefinition>().Create(ModelOne)).Value().Should().BeOfTypeOne()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsNotOne_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<ThreeDefinition>().Create(ModelOne)).Value().Should().BeOfTypeTwo()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsTwo_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<ThreeDefinition>().Create(ModelTwo)).Value().Should().BeOfTypeTwo()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsNotTwo_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<ThreeDefinition>().Create(ModelTwo)).Value().Should().BeOfTypeOne()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsThreeAndExpectedTypeIsThree_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<ThreeDefinition>().Create(ModelThree)).Value().Should().BeOfTypeThree()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsThreeAndExpectedTypeIsNotThree_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<ThreeDefinition>().Create(ModelThree)).Value().Should().BeOfTypeTwo()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<ThreeDefinition>().Create(ModelOne)).Value().Should().BeOfTypeOne().AndValue(value => value.Should().Be(ModelOne))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<ThreeDefinition>().Create(ModelTwo)).Value().Should().BeOfTypeTwo().AndValue(value => value.Should().Be(ModelTwo))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsThreeAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<ThreeDefinition>().Create(ModelThree)).Value().Should().BeOfTypeThree().AndValue(value => value.Should().Be(ModelThree))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 		}
 	}
 }

--- a/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskDefinitionWithTwoTypes.cs
+++ b/src/Functional.Unions.FluentAssertions.Tests/UnionValueTypeAssertionsTests.TaskDefinitionWithTwoTypes.cs
@@ -12,42 +12,42 @@ namespace Functional.Unions.FluentAssertions.Tests
 			[Fact]
 			public void When_EqualityIsTrue_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<TwoDefinition>().Create(ModelTwo)).Value().Should().Be(Union.FromDefinition<TwoDefinition>().Create(ModelTwo).Value())
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_EqualityIsFalse_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<TwoDefinition>().Create(ModelTwo)).Value().Should().Be(Union.FromDefinition<TwoDefinition>().Create(new ClassTwo()).Value())
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsOne_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<TwoDefinition>().Create(ModelOne)).Value().Should().BeOfTypeOne()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsOneAndExpectedTypeIsNotOne_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<TwoDefinition>().Create(ModelOne)).Value().Should().BeOfTypeTwo()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsTwo_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<TwoDefinition>().Create(ModelTwo)).Value().Should().BeOfTypeTwo()
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndExpectedTypeIsNotTwo_Then_ShouldThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<TwoDefinition>().Create(ModelTwo)).Value().Should().BeOfTypeOne()
-			).Should().Throw<Exception>();
+			).Should().ThrowAsync<Exception>();
 
 			[Fact]
 			public void When_TypeIsOneAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<TwoDefinition>().Create(ModelOne)).Value().Should().BeOfTypeOne().AndValue(value => value.Should().Be(ModelOne))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 
 			[Fact]
 			public void When_TypeIsTwoAndAdditionalAssertionSucceeds_Then_ShouldNotThrowException() => new Func<Task>(() =>
 				Task.FromResult(Union.FromDefinition<TwoDefinition>().Create(ModelTwo)).Value().Should().BeOfTypeTwo().AndValue(value => value.Should().Be(ModelTwo))
-			).Should().NotThrow();
+			).Should().NotThrowAsync();
 		}
 	}
 }

--- a/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions.csproj
+++ b/src/Functional.Unions.FluentAssertions/Functional.Unions.FluentAssertions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Justin Cooney + contributors</Authors>
-    <Version>1.0.1</Version>
+    <Version>2.0.0</Version>
     <Description>This package provides extensions to FluentAssertions for the Functional.Unions package.</Description>
     <Copyright>2020</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -21,10 +21,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Functional.Primitives.Extensions" Version="2.4.0" />
-    <PackageReference Include="Functional.Unions" Version="2.4.0" />
-    <PackageReference Include="Functional.Unions.Extensions" Version="2.4.0" />
+	<PackageReference Include="FluentAssertions" Version="[6.*,7.0)" />
+	<PackageReference Include="Functional.Primitives" Version="[2.*,3.0)" />
+	<PackageReference Include="Functional.Primitives.Extensions" Version="[2.*,3.0)" />
+    <PackageReference Include="Functional.Unions" Version="[2.*,3.0)" />
+    <PackageReference Include="Functional.Unions.Extensions" Version="[2.*,3.0)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- update to [`FluentAssertions` `6.0.0`](https://fluentassertions.com/releases/#600) and resolve breaking changes
- add method overload to enable customization of `T` strings for `Option<T>` assertions
- add method overload to enable customization of `TSuccess` and `TFailure` strings for `Result<TSuccess, TFailure>` assertions