### PR TITLE
change namespace of assertions to FluentAssertions for discoverability

### DIFF
--- a/src/Functional.Primitives.FluentAssertions/AndOptionValueConstraint.cs
+++ b/src/Functional.Primitives.FluentAssertions/AndOptionValueConstraint.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 
-namespace Functional.Primitives.FluentAssertions
+// ReSharper disable once CheckNamespace
+namespace FluentAssertions
 {
 	/// <summary>
 	/// Encapsulates a value that assertions will be performed on.

--- a/src/Functional.Primitives.FluentAssertions/AndResultFailureConstraint.cs
+++ b/src/Functional.Primitives.FluentAssertions/AndResultFailureConstraint.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 
-namespace Functional.Primitives.FluentAssertions
+// ReSharper disable once CheckNamespace
+namespace FluentAssertions
 {
 	/// <summary>
 	/// Encapsulates a value that assertions will be performed on.

--- a/src/Functional.Primitives.FluentAssertions/AndResultSuccessConstraint.cs
+++ b/src/Functional.Primitives.FluentAssertions/AndResultSuccessConstraint.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 
-namespace Functional.Primitives.FluentAssertions
+// ReSharper disable once CheckNamespace
+namespace FluentAssertions
 {
 	/// <summary>
 	/// Encapsulates a value that assertions will be performed on.

--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.csproj
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.csproj
@@ -11,7 +11,7 @@
     <RepositoryType></RepositoryType>
     <PackageTags>functional, MSTest, MSTest2, NUnit, xUnit2, xUnit, TDD, Fluent, netcore, netstandard</PackageTags>
     <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.Utilities</PackageProjectUrl>
-    <Version>4.0.0</Version>
+    <Version>4.0.0-prerelease-01</Version>
     <PackageReleaseNotes>Include assertion context for better error messages</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>

--- a/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.csproj
+++ b/src/Functional.Primitives.FluentAssertions/Functional.Primitives.FluentAssertions.csproj
@@ -12,7 +12,7 @@
     <PackageTags>functional, MSTest, MSTest2, NUnit, xUnit2, xUnit, TDD, Fluent, netcore, netstandard</PackageTags>
     <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.Utilities</PackageProjectUrl>
     <Version>4.0.0-prerelease-01</Version>
-    <PackageReleaseNotes>Include assertion context for better error messages</PackageReleaseNotes>
+    <PackageReleaseNotes></PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 

--- a/src/Functional.Primitives.FluentAssertions/FunctionalPrimitiveAssertions.cs
+++ b/src/Functional.Primitives.FluentAssertions/FunctionalPrimitiveAssertions.cs
@@ -1,8 +1,8 @@
 ﻿using System.Threading.Tasks;
-using Functional.Primitives.FluentAssertions;
+using Functional;
 
 // ReSharper disable once CheckNamespace (make assertion methods easy to discover)
-namespace Functional
+namespace FluentAssertions
 {
 	/// <summary>
 	/// Defines additional fluent assertion gateways for types defined in Functional.Primitives namespace.

--- a/src/Functional.Primitives.FluentAssertions/OptionTypeAssertions.cs
+++ b/src/Functional.Primitives.FluentAssertions/OptionTypeAssertions.cs
@@ -4,10 +4,9 @@ using System.Text;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
 using Functional;
-using Functional.Primitives.FluentAssertions;
 using Functional.Primitives.FluentAssertions.Extensions;
 
-// ReSharper disable once CheckNamespace
+// ReSharper disable once CheckNamespace (make assertion methods easy to discover)
 namespace FluentAssertions
 {
 	/// <summary>

--- a/src/Functional.Primitives.FluentAssertions/OptionTypeAssertions.cs
+++ b/src/Functional.Primitives.FluentAssertions/OptionTypeAssertions.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Text;
-using FluentAssertions;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
+using Functional;
+using Functional.Primitives.FluentAssertions;
 using Functional.Primitives.FluentAssertions.Extensions;
 
-namespace Functional.Primitives.FluentAssertions
+// ReSharper disable once CheckNamespace
+namespace FluentAssertions
 {
 	/// <summary>
 	/// Defines assertions for <see cref="Option{TValue}"/> type.

--- a/src/Functional.Primitives.FluentAssertions/OptionTypeAssertionsExtensions.cs
+++ b/src/Functional.Primitives.FluentAssertions/OptionTypeAssertionsExtensions.cs
@@ -1,11 +1,10 @@
-﻿using FluentAssertions;
-using FluentAssertions.Primitives;
-using Functional.Primitives.FluentAssertions;
+﻿using FluentAssertions.Primitives;
 using System;
 using System.Threading.Tasks;
+using Functional;
 
-// ReSharper disable once CheckNamespace (ease of discoverability)
-namespace Functional
+// ReSharper disable once CheckNamespace (make assertion methods easy to discover)
+namespace FluentAssertions
 {
 	/// <summary>
 	/// A collection of extensions for <see cref="OptionTypeAssertions{T}"/>

--- a/src/Functional.Primitives.FluentAssertions/ResultTypeAssertions.cs
+++ b/src/Functional.Primitives.FluentAssertions/ResultTypeAssertions.cs
@@ -4,10 +4,9 @@ using System.Text;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
 using Functional;
-using Functional.Primitives.FluentAssertions;
 using Functional.Primitives.FluentAssertions.Extensions;
 
-// ReSharper disable once CheckNamespace
+// ReSharper disable once CheckNamespace (make assertion methods easy to discover)
 namespace FluentAssertions
 {
 	/// <summary>

--- a/src/Functional.Primitives.FluentAssertions/ResultTypeAssertions.cs
+++ b/src/Functional.Primitives.FluentAssertions/ResultTypeAssertions.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Text;
-using FluentAssertions;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
+using Functional;
+using Functional.Primitives.FluentAssertions;
 using Functional.Primitives.FluentAssertions.Extensions;
 
-// ReSharper disable ImpureMethodCallOnReadonlyValueField
-namespace Functional.Primitives.FluentAssertions
+// ReSharper disable once CheckNamespace
+namespace FluentAssertions
 {
 	/// <summary>
 	/// Defines assertions for <see cref="Result{TSuccess,TFailure}"/> type.

--- a/src/Functional.Primitives.FluentAssertions/ResultTypeAssertionsExtensions.cs
+++ b/src/Functional.Primitives.FluentAssertions/ResultTypeAssertionsExtensions.cs
@@ -1,11 +1,10 @@
-﻿using FluentAssertions;
-using FluentAssertions.Primitives;
-using Functional.Primitives.FluentAssertions;
+﻿using FluentAssertions.Primitives;
 using System;
 using System.Threading.Tasks;
+using Functional;
 
-// ReSharper disable once CheckNamespace (ease of discoverability)
-namespace Functional
+// ReSharper disable once CheckNamespace (make assertion methods easy to discover)
+namespace FluentAssertions
 {
 	/// <summary>
 	/// A collection of extensions for <see cref="ResultTypeAssertions{TSuccess, TFailure}"/>


### PR DESCRIPTION
Using a different namespace required some irritating namespace resolutions whenever both the core `FluentAssertions` library and this library were used within the same file.  I've changed the namespace of the assertion methods for `Option<T>` and `Result<TSuccess, TFailure>` as an experiment for a prerelease package.